### PR TITLE
Update to use forked formula-bump-pr

### DIFF
--- a/.github/workflows/publish-formula-update.yml
+++ b/.github/workflows/publish-formula-update.yml
@@ -21,8 +21,8 @@ jobs:
     name: Create PR
     runs-on: ubuntu-latest
     steps:
-      - name: Homebrew bump formula
-        uses: dawidd6/action-homebrew-bump-formula@v3.1.1
+      - name: kpenfound fork of dawidd6 Homebrew bump formula
+        uses: kpenfound/action-homebrew-bump-formula@v3.2.3
         with:
           token: ${{secrets.HOMEBREW_TOKEN}}
           tap: hashicorp/homebrew-tap


### PR DESCRIPTION
Uses the forked of action-formula-bump-pr to pass `--version` through

[Action here](https://github.com/marketplace/actions/kpenfound-fork-of-dawidd6-homebrew-bump-formula?version=v3.2.3)