### PR TITLE
Remove linux release support for now

### DIFF
--- a/Formula/nomad.rb
+++ b/Formula/nomad.rb
@@ -6,11 +6,6 @@ class Nomad < Formula
     if OS.mac?
       url "https://releases.hashicorp.com/nomad/0.11.3/nomad_0.11.3_darwin_amd64.zip"
       sha256 "5c4087d6e79e1465bd9464d17d196b489abfb0c3c1290fc56ab88843d92a08da"
-    elsif OS.linux?
-      if Hardware::CPU.intel?
-        url "https://releases.hashicorp.com/nomad/0.11.3/nomad_0.11.3_linux_amd64.zip"
-        sha256 "f6a38099e27e8ff1dd7e1fe7215c954ebe4986d05ed6320739186ff3502bb78a"
-      end
     end
     conflicts_with "nomad"
     def install

--- a/Formula/packer.rb
+++ b/Formula/packer.rb
@@ -6,11 +6,6 @@ class Packer < Formula
     if OS.mac?
       url "https://releases.hashicorp.com/packer/1.6.0/packer_1.6.0_darwin_amd64.zip"
       sha256 "118b32c3caa07fa8f824e6b9c89f2a7a94c3f3dbde73d79cd75c6f72662a0230"
-    elsif OS.linux?
-      if Hardware::CPU.intel?
-        url "https://releases.hashicorp.com/packer/1.6.0/packer_1.6.0_linux_amd64.zip"
-        sha256 "a678c995cb8dc232db3353881723793da5acc15857a807d96c52e96e671309d9"
-      end
     end
     conflicts_with "packer"
     def install

--- a/Formula/terraform.rb
+++ b/Formula/terraform.rb
@@ -6,11 +6,6 @@ class Terraform < Formula
     if OS.mac?
       url "https://releases.hashicorp.com/terraform/0.12.28/terraform_0.12.28_darwin_amd64.zip"
       sha256 "893050bcfc5e7445acd3a30f1500227b989b29cbd958ca64a8233589194a198d"
-    elsif OS.linux?
-      if Hardware::CPU.intel?
-        url "https://releases.hashicorp.com/terraform/0.12.28/terraform_0.12.28_linux_amd64.zip"
-        sha256 "be99da1439a60942b8d23f63eba1ea05ff42160744116e84f46fc24f1a8011b6"
-      end
     end
     conflicts_with "terraform"
     def install

--- a/Formula/vault.rb
+++ b/Formula/vault.rb
@@ -6,12 +6,7 @@ class Vault < Formula
 
   if OS.mac?
     url "https://releases.hashicorp.com/vault/1.4.3/vault_1.4.3_darwin_amd64.zip"
-    sha256 "30d08188fd251a4e214c3a320472ee0b27b0499522860b7061bf0e49bc5fc466"
-  elsif OS.linux?
-    if Hardware::CPU.intel?
-      url "https://releases.hashicorp.com/vault/1.4.3/vault_1.4.3_linux_amd64.zip"
-      sha256 "f486da4f6d08e42eb2c17e95cf36cc7f9d9c0e7cc8ced06ce3fca7c3abd7db3d"
-    end
+    sha256 "2198a1e7b5a006434f6acb22ec39d45d17315477a86e2f9d85e2f6f5e845483c"
   end
 
   conflicts_with "vault"


### PR DESCRIPTION
bump-formula-pr tries to determine the SHA, and we aren't specifically passing it to the script yet.  For the moment, take out linux support and work on getting the shas generated