### PR TITLE
Lambda get latest version

### DIFF
--- a/util/lambda_trigger/lambda_trigger.go
+++ b/util/lambda_trigger/lambda_trigger.go
@@ -70,7 +70,12 @@ func HandleLambdaEvent(snsEvent events.SNSEvent) error {
 		}
 
 		if shouldTriggerWorkflow(event.Product) {
-			err := triggerGithubWorkflow(event)
+			version, err := getLatestReleaseVersion(event.Product)
+			if err != nil {
+				return err
+			}
+			event.Version = version.Version
+			err = triggerGithubWorkflow(event)
 
 			return err
 		}

--- a/util/lambda_trigger/lambda_trigger.go
+++ b/util/lambda_trigger/lambda_trigger.go
@@ -70,7 +70,7 @@ func HandleLambdaEvent(snsEvent events.SNSEvent) error {
 		}
 
 		if shouldTriggerWorkflow(event.Product) {
-			version, err := getLatestReleaseVersion(event.Product, true, true)
+			version, err := getLatestVersion(event.Product)
 			if err != nil {
 				return err
 			}

--- a/util/lambda_trigger/lambda_trigger.go
+++ b/util/lambda_trigger/lambda_trigger.go
@@ -70,7 +70,7 @@ func HandleLambdaEvent(snsEvent events.SNSEvent) error {
 		}
 
 		if shouldTriggerWorkflow(event.Product) {
-			version, err := getLatestReleaseVersion(event.Product)
+			version, err := getLatestReleaseVersion(event.Product, true, true)
 			if err != nil {
 				return err
 			}

--- a/util/lambda_trigger/releases.go
+++ b/util/lambda_trigger/releases.go
@@ -1,19 +1,19 @@
 package main
 
 import (
-	hr "github.com/gulducat/hashi-bin/types"
+	hb "github.com/gulducat/hashi-bin/types"
 )
 
 const ReleasesURL = "https://releases.hashicorp.com/index.json"
 
-func getLatestVersion(productName string) (*hr.Version, error) {
-	index, err := hr.NewIndex(ReleasesURL)
+func getLatestVersion(productName string) (*hb.Version, error) {
+	index, err := hb.NewIndex(ReleasesURL)
 	if err != nil {
-		return &hr.Version{}, err
+		return &hb.Version{}, err
 	}
 	product, err := index.GetProduct(productName)
 	if err != nil {
-		return &hr.Version{}, err
+		return &hb.Version{}, err
 	}
 	return product.LatestVersion(), nil
 }

--- a/util/lambda_trigger/releases.go
+++ b/util/lambda_trigger/releases.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	semver "github.com/coreos/go-semver/semver"
+)
+
+// ReleaseResponse object format from releases.hashicorp.com/*/index.json
+type ReleaseResponse struct {
+	Name     string
+	Versions map[string]ReleaseVersion
+}
+
+// ReleaseVersion name, version, and shasum of a release
+type ReleaseVersion struct {
+	Name             string
+	Version          string
+	Shasums          string
+	ShasumsSignature string
+	Builds           []ReleaseBuild
+}
+
+// ReleaseBuild individual build information of a release
+type ReleaseBuild struct {
+	Name     string
+	Version  string
+	OS       string
+	Arch     string
+	Filename string
+	URL      string
+}
+
+func getLatestReleaseVersion(product string) (ReleaseVersion, error) {
+	resp, err := http.Get(fmt.Sprintf("https://releases.hashicorp.com/%s/", product))
+	if err != nil {
+		return ReleaseVersion{}, err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return ReleaseVersion{}, err
+	}
+
+	releaseResponse := &ReleaseResponse{}
+	err = json.Unmarshal([]byte(body), releaseResponse)
+	if err != nil {
+		return ReleaseVersion{}, err
+	}
+
+	latest := ReleaseVersion{Version: "0.0.0"}
+
+	for versionString, releaseVersion := range releaseResponse.Versions {
+		less, err := compareVersionStrings(latest.Version, versionString)
+		if err != nil || less {
+			latest = releaseVersion
+		}
+	}
+
+	return latest, nil
+}
+
+func compareVersionStrings(a string, b string) (bool, error) {
+	aVersion, err := semver.NewVersion(a)
+	if err != nil {
+		return false, err
+	}
+
+	bVersion, err := semver.NewVersion(b)
+	if err != nil {
+		return false, err
+	}
+
+	return aVersion.LessThan(*bVersion), nil
+}

--- a/util/lambda_trigger/releases.go
+++ b/util/lambda_trigger/releases.go
@@ -4,6 +4,7 @@ import (
 	hb "github.com/gulducat/hashi-bin/types"
 )
 
+// ReleasesURL The url to read the releases index from
 const ReleasesURL = "https://releases.hashicorp.com/index.json"
 
 func getLatestVersion(productName string) (*hb.Version, error) {


### PR DESCRIPTION
This has lambda to get the latest version of the product specified in the event.

It does this by querying the index.json of the product on releases.hashicorp.com and using semver to find the latest version.  We can further filter this if we want to limit by OS or Architecture.  This PR is currently filtering out enterprise and prerelease builds.