### PR TITLE
Update Trigger to compare Formula version

### DIFF
--- a/.github/workflows/publish-formula-update.yml
+++ b/.github/workflows/publish-formula-update.yml
@@ -10,15 +10,15 @@ jobs:
     name: Create PR
     runs-on: ubuntu-latest
     steps:
-      - name: kpenfound fork of dawidd6 Homebrew bump formula
-        uses: kpenfound/action-homebrew-bump-formula@v3.2.3
+      - name: Homebrew bump formula
+        uses: dawidd6/action-homebrew-bump-formula@v3.3.0
         with:
           token: ${{secrets.HOMEBREW_TOKEN}}
           tap: hashicorp/homebrew-tap
           formula: ${{github.event.client_payload.name}}
           tag: ${{github.event.client_payload.version}}
-      - name: kpenfound fork of Merge pull requests
-        uses: kpenfound/automerge-action@v0.9.0
+      - name: Merge pull requests
+        uses: pascalgn/automerge-action@v0.9.0
         env:
           GITHUB_TOKEN: "${{secrets.HOMEBREW_TOKEN}}"
           MERGE_LABELS: ""

--- a/util/lambda_trigger/lambda_trigger.go
+++ b/util/lambda_trigger/lambda_trigger.go
@@ -106,7 +106,7 @@ func HandleLambdaEvent(snsEvent events.SNSEvent) error {
 			}
 
 			if event.Version == oldVersion {
-				return errors.New("No new version to publish")
+				return errors.New("formula is already latest version")
 			}
 
 			err = triggerGithubWorkflow(event)

--- a/util/lambda_trigger/lambda_trigger.go
+++ b/util/lambda_trigger/lambda_trigger.go
@@ -34,25 +34,23 @@ func isProductSupported(product string) bool {
 }
 
 func getFormulaVersion(product string) (string, error) {
-	version := ""
 	formulaURL := fmt.Sprintf("https://raw.githubusercontent.com/hashicorp/homebrew-tap/master/Formula/%s.rb", product)
 	resp, err := http.Get(formulaURL)
 	if err != nil {
-		return version, err
+		return "", err
 	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return version, err
+		return "", err
 	}
 
 	re := regexp.MustCompile(`version "(.+)"`)
 	matched := re.FindStringSubmatch(string(body))
 	if matched == nil || len(matched) < 2 {
-		return version, errors.New("No version found in formula")
+		return "", errors.New("No version found in formula")
 	}
-	version = matched[1]
-	return version, nil
+	return matched[1], nil
 }
 
 func triggerGithubWorkflow(event *ReleaseEvent) error {

--- a/util/lambda_trigger/lambda_trigger_test.go
+++ b/util/lambda_trigger/lambda_trigger_test.go
@@ -16,3 +16,10 @@ func TestGetFormulaVersion(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, test_version, gotLatest)
 }
+
+func TestGetLatestVersion(t *testing.T) {
+	gotLatest, err := getLatestVersion(test_product)
+
+	require.Nil(t, err)
+	assert.Equal(t, test_version, gotLatest.Version)
+}

--- a/util/lambda_trigger/lambda_trigger_test.go
+++ b/util/lambda_trigger/lambda_trigger_test.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const test_product = "nomad"
+const test_version = "0.12.2"
+
+func TestGetFormulaVersion(t *testing.T) {
+	gotLatest, err := getFormulaVersion(test_product)
+
+	require.Nil(t, err)
+	assert.Equal(t, test_version, gotLatest)
+}


### PR DESCRIPTION
This checks if the "latest" version of the product triggering the workflow is the same as the existing Formula version to avoid doing too much work.

This can happen if the trigger came from:
 - Enterprise build
 - Pre-release build
 - Patching an older major/minor

Also update our GH actions since my forked actions have been merged