### PR TITLE
Add linux to waypoint formula

### DIFF
--- a/Formula/waypoint.rb
+++ b/Formula/waypoint.rb
@@ -1,12 +1,21 @@
 class Waypoint < Formula
   desc "Waypoint"
   homepage "https://www.waypointproject.io/"
-
-  url "https://releases.hashicorp.com/waypoint/0.1.3/waypoint_0.1.3_darwin_amd64.zip"
-
   version "0.1.3"
-  sha256 "99ab1d760e9f4afc97f52c0c3c5724c104b0027a85b1cf8174cabb4c77ce60d6"
   bottle :unneeded
+
+  if OS.mac?
+    url "https://releases.hashicorp.com/waypoint/0.1.3/waypoint_0.1.3_darwin_amd64.zip"
+    sha256 "99ab1d760e9f4afc97f52c0c3c5724c104b0027a85b1cf8174cabb4c77ce60d6"
+  elsif OS.linux?
+    if Hardware::CPU.intel?
+      url "https://releases.hashicorp.com/waypoint/0.1.3/waypoint_0.1.3_linux_amd64.zip"
+      sha256 "bdf668eacd418ca412df9a93e9c243d790653eea75df608a242965ef79998633"
+    else
+      url "https://releases.hashicorp.com/waypoint/0.1.3/waypoint_0.1.3_linux_arm.zip"
+      sha256 "5eeb40fb850c3932463cb56a8a61a0283a06b9cbd40d3a2f230670f7783bb54a"
+    end
+  end
 
   #conflicts_with "waypoint"
 

--- a/Formula/waypoint.rb
+++ b/Formula/waypoint.rb
@@ -1,18 +1,18 @@
 class Waypoint < Formula
   desc "Waypoint"
   homepage "https://www.waypointproject.io/"
-  version "0.1.3"
+  version "0.1.2"
   bottle :unneeded
 
   if OS.mac?
-    url "https://releases.hashicorp.com/waypoint/0.1.3/waypoint_0.1.3_darwin_amd64.zip"
+    url "https://releases.hashicorp.com/waypoint/0.1.2/waypoint_0.1.2_darwin_amd64.zip"
     sha256 "99ab1d760e9f4afc97f52c0c3c5724c104b0027a85b1cf8174cabb4c77ce60d6"
   elsif OS.linux?
     if Hardware::CPU.intel?
-      url "https://releases.hashicorp.com/waypoint/0.1.3/waypoint_0.1.3_linux_amd64.zip"
+      url "https://releases.hashicorp.com/waypoint/0.1.2/waypoint_0.1.2_linux_amd64.zip"
       sha256 "bdf668eacd418ca412df9a93e9c243d790653eea75df608a242965ef79998633"
     else
-      url "https://releases.hashicorp.com/waypoint/0.1.3/waypoint_0.1.3_linux_arm.zip"
+      url "https://releases.hashicorp.com/waypoint/0.1.2/waypoint_0.1.2_linux_arm.zip"
       sha256 "5eeb40fb850c3932463cb56a8a61a0283a06b9cbd40d3a2f230670f7783bb54a"
     end
   end

--- a/Formula/waypoint.rb
+++ b/Formula/waypoint.rb
@@ -10,7 +10,7 @@ class Waypoint < Formula
   elsif OS.linux?
     if Hardware::CPU.intel?
       url "https://releases.hashicorp.com/waypoint/0.1.2/waypoint_0.1.2_linux_amd64.zip"
-      sha256 "bdf668eacd418ca412df9a93e9c243d790653eea75df608a242965ef79998633"
+      sha256 "05c2be901fa0cc24e4bd40c96267f9af7d8b62fe75e0a2f1b5862179bbc81c11"
     else
       url "https://releases.hashicorp.com/waypoint/0.1.2/waypoint_0.1.2_linux_arm.zip"
       sha256 "5eeb40fb850c3932463cb56a8a61a0283a06b9cbd40d3a2f230670f7783bb54a"


### PR DESCRIPTION
I'd like to help get linux supported with the brew formula for hashicorp tools. I updated the waypoint template manually for 1.3 (this PR) but I'm having trouble running `brew bump-formula-pr` that is run in github actions for the automated releases.

I'm not 100% sure that command works with formula that support macOS and Linux so I was trying to test but running in to errors.

```
Error: Calling Non-checksummed download of waypoint formula file from an arbitrary URL is disabled! Use 'brew extract' or 'brew create' and 'brew tap-new' to create a formula file in a tap on GitHub instead.
```

Is there a way to test that command locally or with a fork of the repo?

I wanted to open this PR to figure out the best way to support this by the maintainers of the tap.