### PR TITLE
Added correct syntax for SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ available in search results (`brew search` output):
 brew tap hashicorp/tap
 ```
 
+Note: to clone the tap via SSH you will need to use:
+
+```sh
+brew tap hasicorp/tap https://github.com/hashicorp/homebrew-tap
+```
+
 While you may search across taps, it is necessary to always use
 fully qualified name (incl. the `hashicorp/tap/` prefix)
 when refering to formulae in external taps such as this one


### PR DESCRIPTION
When authenticating via SSH you need to provide the URL as well as the tap name.