### PR TITLE
Add boundary-desktop as a Cask

### DIFF
--- a/Casks/hashicorp-boundary-desktop.rb
+++ b/Casks/hashicorp-boundary-desktop.rb
@@ -1,0 +1,11 @@
+cask "hashicorp-boundary-desktop" do
+  version "1.0.0-alpha"
+  sha256 "7a5ecb05bb7056a8ed95e2f8ef9fb06fd1f200c568423d410ab0670204baad32"
+
+  url "https://releases.hashicorp.com/boundary-desktop/#{version}/boundary-desktop_#{version}_darwin_amd64.dmg"
+  name "Boundary Desktop"
+  desc ""
+  homepage "https://www.boundaryproject.io/"
+
+  app "Boundary Desktop.app"
+end

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ outside of search.
 
 With the following commands, you can install the latest version of each product:
 ```sh
+# Formulae
 brew install hashicorp/tap/boundary
 brew install hashicorp/tap/consul
 brew install hashicorp/tap/nomad
@@ -47,9 +48,12 @@ brew install hashicorp/tap/terraform
 brew install hashicorp/tap/vault
 brew install hashicorp/tap/waypoint
 
-brew cask install vagrant
+# Casks
+brew install hashicorp-boundary-desktop
+
+brew install vagrant
 ```
-* Note: Vagrant is available as a cask from Homebrew core. It is packaged as a cask to include required dependencies of Vagrant.
+* Note: Vagrant is available as a cask from Homebrew core and not provided by this tap.
 
 ## Why should I install packages from this tap?
 


### PR DESCRIPTION
Automation currently doesn't support this, so updates will be manual for the moment