### PR TITLE
Provide apple silicon compat for non-arm builds

### DIFF
--- a/util/formula_templater/formula.go
+++ b/util/formula_templater/formula.go
@@ -67,8 +67,7 @@ const formulaTemplate = `class {{ .Name }} < Formula
   homepage "{{ .Homepage }}"
   version "{{ .Version }}"
 
-  {{- if .Architectures.DarwinAmd64 }}
-  {{- if .Architectures.DarwinArm64 }}
+  {{- if and .Architectures.DarwinAmd64 .Architectures.DarwinArm64 }}
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://releases.hashicorp.com/{{ .Product }}/{{ .Version }}/{{ .Product }}_{{ .Version }}_darwin_amd64.zip"
@@ -85,7 +84,6 @@ const formulaTemplate = `class {{ .Name }} < Formula
     url "https://releases.hashicorp.com/{{ .Product }}/{{ .Version }}/{{ .Product }}_{{ .Version }}_darwin_amd64.zip"
     sha256 "{{ .Architectures.DarwinAmd64SHA }}"
   end
-  {{- end }}
   {{- end }}
   {{- if .Architectures.LinuxAmd64 }}
 

--- a/util/formula_templater/formula.go
+++ b/util/formula_templater/formula.go
@@ -84,6 +84,16 @@ const formulaTemplate = `class {{ .Name }} < Formula
     url "https://releases.hashicorp.com/{{ .Product }}/{{ .Version }}/{{ .Product }}_{{ .Version }}_darwin_amd64.zip"
     sha256 "{{ .Architectures.DarwinAmd64SHA }}"
   end
+
+  if OS.mac? && Hardware::CPU.arm?
+    def caveats
+      <<~EOS
+        The darwin_arm64 architecture is not supported for this product
+        at this time.  The darwin_amd64 binary has been installed and
+        is not guaranteed to work.
+      EOS
+    end
+  end
   {{- end }}
   {{- if .Architectures.LinuxAmd64 }}
 

--- a/util/formula_templater/formula.go
+++ b/util/formula_templater/formula.go
@@ -89,8 +89,9 @@ const formulaTemplate = `class {{ .Name }} < Formula
     def caveats
       <<~EOS
         The darwin_arm64 architecture is not supported for this product
-        at this time.  The darwin_amd64 binary has been installed and
-        is not guaranteed to work.
+        at this time, however we do plan to support this in the future. The
+        darwin_amd64 binary has been installed and may work in
+        compatibility mode, but it is not fully supported.
       EOS
     end
   end

--- a/util/formula_templater/formula.go
+++ b/util/formula_templater/formula.go
@@ -68,18 +68,24 @@ const formulaTemplate = `class {{ .Name }} < Formula
   version "{{ .Version }}"
 
   {{- if .Architectures.DarwinAmd64 }}
+  {{- if .Architectures.DarwinArm64 }}
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://releases.hashicorp.com/{{ .Product }}/{{ .Version }}/{{ .Product }}_{{ .Version }}_darwin_amd64.zip"
     sha256 "{{ .Architectures.DarwinAmd64SHA }}"
   end
-  {{- end }}
-  {{- if .Architectures.DarwinArm64 }}
 
   if OS.mac? && Hardware::CPU.arm?
     url "https://releases.hashicorp.com/{{ .Product }}/{{ .Version }}/{{ .Product }}_{{ .Version }}_darwin_arm64.zip"
     sha256 "{{ .Architectures.DarwinArm64SHA }}"
   end
+  {{- else }}
+
+  if OS.mac?
+    url "https://releases.hashicorp.com/{{ .Product }}/{{ .Version }}/{{ .Product }}_{{ .Version }}_darwin_amd64.zip"
+    sha256 "{{ .Architectures.DarwinAmd64SHA }}"
+  end
+  {{- end }}
   {{- end }}
   {{- if .Architectures.LinuxAmd64 }}
 

--- a/util/formula_templater/formula_test.go
+++ b/util/formula_templater/formula_test.go
@@ -18,7 +18,7 @@ func TestPrintFormula(t *testing.T) {
   homepage "https://www.consul.io"
   version "1.9.4"
 
-  if OS.mac? && Hardware::CPU.intel?
+  if OS.mac?
     url "https://releases.hashicorp.com/consul/1.9.4/consul_1.9.4_darwin_amd64.zip"
     sha256 "c168240d52f67c71b30ef51b3594673cad77d0dbbf38c412b2ee30b39ef30843"
   end

--- a/util/formula_templater/formula_test.go
+++ b/util/formula_templater/formula_test.go
@@ -23,6 +23,16 @@ func TestPrintFormula(t *testing.T) {
     sha256 "c168240d52f67c71b30ef51b3594673cad77d0dbbf38c412b2ee30b39ef30843"
   end
 
+  if OS.mac? && Hardware::CPU.arm?
+    def caveats
+      <<~EOS
+        The darwin_arm64 architecture is not supported for this product
+        at this time.  The darwin_amd64 binary has been installed and
+        is not guaranteed to work.
+      EOS
+    end
+  end
+
   if OS.linux? && Hardware::CPU.intel?
     url "https://releases.hashicorp.com/consul/1.9.4/consul_1.9.4_linux_amd64.zip"
     sha256 "da3919197ef33c4205bb7df3cc5992ccaae01d46753a72fe029778d7f52fb610"

--- a/util/formula_templater/formula_test.go
+++ b/util/formula_templater/formula_test.go
@@ -27,8 +27,9 @@ func TestPrintFormula(t *testing.T) {
     def caveats
       <<~EOS
         The darwin_arm64 architecture is not supported for this product
-        at this time.  The darwin_amd64 binary has been installed and
-        is not guaranteed to work.
+        at this time, however we do plan to support this in the future. The
+        darwin_amd64 binary has been installed and may work in
+        compatibility mode, but it is not fully supported.
       EOS
     end
   end


### PR DESCRIPTION
Fixes https://github.com/hashicorp/homebrew-tap/issues/134

This changes the formula output like so:

Product has darwin_amd64 and darwin_arm64 binaries:
```
  if OS.mac? && Hardware::CPU.intel?
    url "https://releases.hashicorp.com/waypoint/0.2.4/waypoint_0.2.4_darwin_amd64.zip"
    sha256 "bda5d7427379d8679b7475a8c04ccf522ef2bbad6c20bc3bc3ecfe7a63a075c1"
  end

  if OS.mac? && Hardware::CPU.arm?
    url "https://releases.hashicorp.com/waypoint/0.2.4/waypoint_0.2.4_darwin_arm64.zip"
    sha256 "713c73e67297fc31cfdaab26252ec4c3febef2a949353b2786af9cb21a372f9d"
  end
```

Product only has darwin_amd64 binary:
```
  if OS.mac?
    url "https://releases.hashicorp.com/vault/1.7.0/vault_1.7.0_darwin_amd64.zip"
    sha256 "374fca0c8fcde45d5710e06673d03596371e92e18c33612396484758d2967d07"
  end
```

I'll regenerate the existing formulae once this is approved and merged.

This doesn't guarantee Rosetta functionality, but it will allow silicon users to use the tap!