### PR TITLE
terraform: enable darwin/arm64 (RELENG-650)

### DIFF
--- a/util/formula_templater/config.hcl
+++ b/util/formula_templater/config.hcl
@@ -152,7 +152,7 @@ formula {
     homepage = "https://www.terraform.io/"
     architectures {
         darwin_amd64 = true
-        darwin_arm64 = false
+        darwin_arm64 = true
         linux_amd64 = true
         linux_arm = true
         linux_arm64 = true


### PR DESCRIPTION
~Iterating on this code over at https://app.circleci.com/pipelines/github/hashicorp/terraform-releases?branch=release%2F9.9.9-sam-test-do-not-release-darwin-arm64 - there's currently a failure uploading the arm64 binary for notarization. I'll pick this up in the morning (2021-07-01).~ (this comment was intended for a different PR)