### PR TITLE
Fix update detection for casks

### DIFF
--- a/util/lambda_trigger/lambda_trigger_test.go
+++ b/util/lambda_trigger/lambda_trigger_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 const test_product = "nomad"
-const test_version = "0.12.3"
+const test_version = "1.1.2"
 
 func TestGetFormulaVersion(t *testing.T) {
 	gotLatest, err := getFormulaVersion(test_product)


### PR DESCRIPTION
Previously, while Cask support was supposed to be working, the `getFormulaVersion` wasn't actually able to see the cask version and therefore not triggering an update to casks