### PR TITLE
Including binary build for macOS arm64

### DIFF
--- a/Formula/vault.rb
+++ b/Formula/vault.rb
@@ -9,14 +9,8 @@ class Vault < Formula
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    def caveats
-      <<~EOS
-        The darwin_arm64 architecture is not supported for this product
-        at this time, however we do plan to support this in the future. The
-        darwin_amd64 binary has been installed and may work in
-        compatibility mode, but it is not fully supported.
-      EOS
-    end
+    url "https://releases.hashicorp.com/vault/1.8.0/vault_1.8.0_darwin_arm64.zip"
+    sha256 "b057d5314f66609510975236d7ed62825151a45d1dfa079f611d2302fa62b483"
   end
 
   if OS.linux? && Hardware::CPU.intel?


### PR DESCRIPTION
I've taken the liberty of including the download URL for the ARM64 build.