### PR TITLE
fix update trigger by reading s3 directly

### DIFF
--- a/util/lambda_trigger/releases.go
+++ b/util/lambda_trigger/releases.go
@@ -5,7 +5,7 @@ import (
 )
 
 // ReleasesURL The url to read the releases index from
-const ReleasesURL = "http://hc-releases-prod.s3-website-us-east-1.amazonaws.com/index.json"
+const ReleasesURL = "https://hc-releases-prod.s3.amazonaws.com/index.json"
 
 func getLatestVersion(productName string) (*hb.Version, error) {
 	index, err := hb.NewIndex(ReleasesURL)


### PR DESCRIPTION
Sometimes the check doesn't see a new version, likely because the s3 website does some caching.  Accessing the s3 object directly should do it since the linux packaging trigger does this and does not encounter any issues.