### PR TITLE
Remove deprecated bottle unneeded

### DIFF
--- a/Formula/boundary.rb
+++ b/Formula/boundary.rb
@@ -34,8 +34,6 @@ class Boundary < Formula
     sha256 "6979dfad5bd7e12503c75858a82603adb1ff8c5a5a902a101f81a794f7052386"
   end
 
-  bottle :unneeded
-
   conflicts_with "boundary"
 
   def install

--- a/Formula/consul-template.rb
+++ b/Formula/consul-template.rb
@@ -29,8 +29,6 @@ class ConsulTemplate < Formula
     sha256 "ee6d18c70664dbb0eb3f1061188112aaef7b0cf972e8a409c8209ffd488e8567"
   end
 
-  bottle :unneeded
-
   conflicts_with "consul-template"
 
   def install

--- a/Formula/consul-terraform-sync.rb
+++ b/Formula/consul-terraform-sync.rb
@@ -29,8 +29,6 @@ class ConsulTerraformSync < Formula
     sha256 "c2f644b1643c647a88ff8aad20f15a4700be2fb88137cbb73c0905864e75c3c2"
   end
 
-  bottle :unneeded
-
   conflicts_with "consul-terraform-sync"
 
   def install

--- a/Formula/consul.rb
+++ b/Formula/consul.rb
@@ -29,8 +29,6 @@ class Consul < Formula
     sha256 "a6caf82433c48a8938bd308a8593c7336e8a0a9f841c7f1426ea7903b73cc8a1"
   end
 
-  bottle :unneeded
-
   conflicts_with "consul"
 
   def install

--- a/Formula/nomad.rb
+++ b/Formula/nomad.rb
@@ -34,8 +34,6 @@ class Nomad < Formula
     sha256 "9e8a8171ab06caceca84bd8bd8f96cc0d7649cd504ea99d93bf13070743f8fd5"
   end
 
-  bottle :unneeded
-
   conflicts_with "nomad"
 
   def install

--- a/Formula/packer.rb
+++ b/Formula/packer.rb
@@ -28,8 +28,6 @@ class Packer < Formula
     sha256 "c44d4f4c6776154a95a700c4b8caefb07c96652deb4ca6b265d19d767b31faeb"
   end
 
-  bottle :unneeded
-
   conflicts_with "packer"
 
   def install

--- a/Formula/sentinel.rb
+++ b/Formula/sentinel.rb
@@ -34,8 +34,6 @@ class Sentinel < Formula
     sha256 ""
   end
 
-  bottle :unneeded
-
   conflicts_with "sentinel"
 
   def install

--- a/Formula/terraform-ls.rb
+++ b/Formula/terraform-ls.rb
@@ -6,7 +6,6 @@ class TerraformLs < Formula
   desc "Terraform Language Server"
   homepage "https://github.com/hashicorp/terraform-ls"
   version "0.23.0"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.arm?

--- a/Formula/terraform.rb
+++ b/Formula/terraform.rb
@@ -28,8 +28,6 @@ class Terraform < Formula
     sha256 "457ac590301126e7b151ea08c5b9586a882c60039a0605fb1e44b8d23d2624fd"
   end
 
-  bottle :unneeded
-
   conflicts_with "terraform"
 
   def install

--- a/Formula/vault.rb
+++ b/Formula/vault.rb
@@ -28,8 +28,6 @@ class Vault < Formula
     sha256 "3270ac43fe2c2923cbbef274017c62ca521762c50fdc839c0bc0edf872072a07"
   end
 
-  bottle :unneeded
-
   conflicts_with "vault"
 
   def install

--- a/Formula/waypoint.rb
+++ b/Formula/waypoint.rb
@@ -23,8 +23,6 @@ class Waypoint < Formula
     sha256 "729e70ac41356d02ed822edaa75d7d341194aca1dc89b774efa967386f52f7b8"
   end
 
-  bottle :unneeded
-
   conflicts_with "waypoint"
 
   def install

--- a/util/formula_templater/formula.go
+++ b/util/formula_templater/formula.go
@@ -119,8 +119,6 @@ const formulaTemplate = `class {{ .Name }} < Formula
 
   {{- end }}
 
-  bottle :unneeded
-
   {{- with .Depends }}
   {{ range $index, $element := . }}
   depends_on "{{ . }}"

--- a/util/formula_templater/formula_test.go
+++ b/util/formula_templater/formula_test.go
@@ -44,8 +44,6 @@ func TestPrintFormula(t *testing.T) {
     sha256 "012c552aff502f907416c9a119d2dfed88b92e981f9b160eb4fe292676afdaeb"
   end
 
-  bottle :unneeded
-
   conflicts_with "consul"
 
   def install


### PR DESCRIPTION
Closes https://github.com/hashicorp/homebrew-tap/issues/156

`bottle :unneeded` has been deprecated by brew. No longer needed