### PR TITLE
Fix consul ecosystem class names

### DIFF
--- a/Formula/consul-aws.rb
+++ b/Formula/consul-aws.rb
@@ -1,4 +1,4 @@
-class ConsulAWS < Formula
+class ConsulAws < Formula
   desc "Consul AWS"
   homepage "https://github.com/hashicorp/consul-aws"
   version "0.1.2"

--- a/Formula/consul-aws.rb
+++ b/Formula/consul-aws.rb
@@ -1,42 +1,41 @@
 class ConsulAWS < Formula
-    desc "Consul AWS"
-    homepage "https://github.com/hashicorp/consul-aws"
-    version "0.1.2"
-  
-    if OS.mac?
-      url "https://releases.hashicorp.com/consul-aws/0.1.2/consul-aws_0.1.2_darwin_amd64.zip"
-      sha256 "f23c1452f677121dd87b78aa6034afa2d1c2d156639192c239a0048e5354b9c8"
-    end
-  
-    if OS.mac? && Hardware::CPU.arm?
-      def caveats
-        <<~EOS
-          The darwin_arm64 architecture is not supported for this product
-          at this time, however we do plan to support this in the future. The
-          darwin_amd64 binary has been installed and may work in
-          compatibility mode, but it is not fully supported.
-        EOS
-      end
-    end
-  
-    if OS.linux? && Hardware::CPU.intel?
-      url "https://releases.hashicorp.com/consul-aws/0.1.2/consul-aws_0.1.2_linux_amd64.zip"
-      sha256 "c1a44fd4df8c455a6e4279f83938171087901e17fbff46adbe10c9697fbfb503"
-    end
-  
-    if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-      url "https://releases.hashicorp.com/consul-aws/0.1.2/consul-aws_0.1.2_linux_arm64.zip"
-      sha256 "16145d50885aeb6d588b9a35ec4492e5e6960f7c68d4d2f16b0581397e5821f2"
-    end
-  
-    conflicts_with "consul-aws"
-  
-    def install
-      bin.install "consul-aws"
-    end
-  
-    test do
-      system "#{bin}/consul-aws --version"
+  desc "Consul AWS"
+  homepage "https://github.com/hashicorp/consul-aws"
+  version "0.1.2"
+
+  if OS.mac?
+    url "https://releases.hashicorp.com/consul-aws/0.1.2/consul-aws_0.1.2_darwin_amd64.zip"
+    sha256 "f23c1452f677121dd87b78aa6034afa2d1c2d156639192c239a0048e5354b9c8"
+  end
+
+  if OS.mac? && Hardware::CPU.arm?
+    def caveats
+      <<~EOS
+        The darwin_arm64 architecture is not supported for this product
+        at this time, however we do plan to support this in the future. The
+        darwin_amd64 binary has been installed and may work in
+        compatibility mode, but it is not fully supported.
+      EOS
     end
   end
-  
+
+  if OS.linux? && Hardware::CPU.intel?
+    url "https://releases.hashicorp.com/consul-aws/0.1.2/consul-aws_0.1.2_linux_amd64.zip"
+    sha256 "c1a44fd4df8c455a6e4279f83938171087901e17fbff46adbe10c9697fbfb503"
+  end
+
+  if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+    url "https://releases.hashicorp.com/consul-aws/0.1.2/consul-aws_0.1.2_linux_arm64.zip"
+    sha256 "16145d50885aeb6d588b9a35ec4492e5e6960f7c68d4d2f16b0581397e5821f2"
+  end
+
+  conflicts_with "consul-aws"
+
+  def install
+    bin.install "consul-aws"
+  end
+
+  test do
+    system "#{bin}/consul-aws --version"
+  end
+end

--- a/Formula/consul-esm.rb
+++ b/Formula/consul-esm.rb
@@ -1,4 +1,4 @@
-class ConsulESM < Formula
+class ConsulEsm < Formula
   desc "Consul ESM"
   homepage "https://github.com/hashicorp/consul-esm"
   version "0.6.0"

--- a/Formula/consul-esm.rb
+++ b/Formula/consul-esm.rb
@@ -1,42 +1,46 @@
 class ConsulESM < Formula
-    desc "Consul ESM"
-    homepage "https://github.com/hashicorp/consul-esm"
-    version "0.6.0"
-  
-    if OS.mac?
-      url "https://releases.hashicorp.com/consul-esm/0.6.0/consul-esm_0.6.0_darwin_amd64.zip"
-      sha256 "b48bdaaad25ebea94b57527a813cffb66181b8addbc9aebc24ba3f6c5c50c0d6"
-    end
-  
-    if OS.mac? && Hardware::CPU.arm?
-      def caveats
-        <<~EOS
-          The darwin_arm64 architecture is not supported for this product
-          at this time, however we do plan to support this in the future. The
-          darwin_amd64 binary has been installed and may work in
-          compatibility mode, but it is not fully supported.
-        EOS
-      end
-    end
-  
-    if OS.linux? && Hardware::CPU.intel?
-      url "https://releases.hashicorp.com/consul-esm/0.6.0/consul-esm_0.6.0_linux_amd64.zip"
-      sha256 "161a9df2b69a73e70004aef2908a8fd4cbcd86b3586d892934b3c9e7f6fbea94"
-    enda
-  
-    if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-      url "https://releases.hashicorp.com/consul-esm/0.6.0/consul-esm_0.6.0_linux_arm64.zip"
-      sha256 "8a10b4d3337487d4cb6b2f1afdf71a35af2c63bafed6a396b1e5bcd7871d9435"
-    end
-  
-    conflicts_with "consul-esm"
-  
-    def install
-      bin.install "consul-esm"
-    end
-  
-    test do
-      system "#{bin}/consul-esm --version"
+  desc "Consul ESM"
+  homepage "https://github.com/hashicorp/consul-esm"
+  version "0.6.0"
+
+  if OS.mac?
+    url "https://releases.hashicorp.com/consul-esm/0.6.0/consul-esm_0.6.0_darwin_amd64.zip"
+    sha256 "b48bdaaad25ebea94b57527a813cffb66181b8addbc9aebc24ba3f6c5c50c0d6"
+  end
+
+  if OS.mac? && Hardware::CPU.arm?
+    def caveats
+      <<~EOS
+        The darwin_arm64 architecture is not supported for this product
+        at this time, however we do plan to support this in the future. The
+        darwin_amd64 binary has been installed and may work in
+        compatibility mode, but it is not fully supported.
+      EOS
     end
   end
-  
+
+  if OS.linux? && Hardware::CPU.intel?
+    url "https://releases.hashicorp.com/consul-esm/0.6.0/consul-esm_0.6.0_linux_amd64.zip"
+    sha256 "161a9df2b69a73e70004aef2908a8fd4cbcd86b3586d892934b3c9e7f6fbea94"
+  end
+
+  if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
+    url "https://releases.hashicorp.com/consul-esm/0.6.0/consul-esm_0.6.0_linux_arm.zip"
+    sha256 "e06abe49992da7efd2421635d2b5d0342ea5d54ed890c0f646058e1dfcd935b9"
+  end
+
+  if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+    url "https://releases.hashicorp.com/consul-esm/0.6.0/consul-esm_0.6.0_linux_arm64.zip"
+    sha256 "8a10b4d3337487d4cb6b2f1afdf71a35af2c63bafed6a396b1e5bcd7871d9435"
+  end
+
+  conflicts_with "consul-esm"
+
+  def install
+    bin.install "consul-esm"
+  end
+
+  test do
+    system "#{bin}/consul-esm --version"
+  end
+end

--- a/Formula/consul-k8s.rb
+++ b/Formula/consul-k8s.rb
@@ -1,42 +1,46 @@
 class ConsulK8s < Formula
-    desc "Consul K8s"
-    homepage "https://github.com/hashicorp/consul-k8s"
-    version "0.26.0"
-  
-    if OS.mac?
-      url "https://releases.hashicorp.com/consul-k8s/0.26.0/consul-k8s_0.26.0_darwin_amd64.zip"
-      sha256 "dea88d28ae12a1e7f5bae0ebf8eb89d6a7bff0b36f39ba94c62ee17b878bc3eb"
-    end
-  
-    if OS.mac? && Hardware::CPU.arm?
-      def caveats
-        <<~EOS
-          The darwin_arm64 architecture is not supported for this product
-          at this time, however we do plan to support this in the future. The
-          darwin_amd64 binary has been installed and may work in
-          compatibility mode, but it is not fully supported.
-        EOS
-      end
-    end
-  
-    if OS.linux? && Hardware::CPU.intel?
-      url "https://releases.hashicorp.com/consul-k8s/0.26.0/consul-k8s_0.26.0_linux_amd64.zipp"
-      sha256 "9fe6976bbfdfeac7f1947aba4a5ea792d3e3b9a131609fa79789911b652c96e3"
-    enda
-  
-    if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-      url "https://releases.hashicorp.com/consul-k8s/0.26.0/consul-k8s_0.26.0_linux_arm64.zip"
-      sha256 "f9bbab8a19ca85c2518779379e3df5f4362d1d81fa8261c356e39dec9fb16709"
-    end
-  
-    conflicts_with "consul-k8s"
-  
-    def install
-      bin.install "consul-k8s"
-    end
-  
-    test do
-      system "#{bin}/consul-k8s --version"
+  desc "Consul K8s"
+  homepage "https://github.com/hashicorp/consul-k8s"
+  version "0.26.0"
+
+  if OS.mac?
+    url "https://releases.hashicorp.com/consul-k8s/0.26.0/consul-k8s_0.26.0_darwin_amd64.zip"
+    sha256 "dea88d28ae12a1e7f5bae0ebf8eb89d6a7bff0b36f39ba94c62ee17b878bc3eb"
+  end
+
+  if OS.mac? && Hardware::CPU.arm?
+    def caveats
+      <<~EOS
+        The darwin_arm64 architecture is not supported for this product
+        at this time, however we do plan to support this in the future. The
+        darwin_amd64 binary has been installed and may work in
+        compatibility mode, but it is not fully supported.
+      EOS
     end
   end
-  
+
+  if OS.linux? && Hardware::CPU.intel?
+    url "https://releases.hashicorp.com/consul-k8s/0.26.0/consul-k8s_0.26.0_linux_amd64.zip"
+    sha256 "9fe6976bbfdfeac7f1947aba4a5ea792d3e3b9a131609fa79789911b652c96e3"
+  end
+
+  if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
+    url "https://releases.hashicorp.com/consul-k8s/0.26.0/consul-k8s_0.26.0_linux_arm.zip"
+    sha256 ""
+  end
+
+  if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+    url "https://releases.hashicorp.com/consul-k8s/0.26.0/consul-k8s_0.26.0_linux_arm64.zip"
+    sha256 "f9bbab8a19ca85c2518779379e3df5f4362d1d81fa8261c356e39dec9fb16709"
+  end
+
+  conflicts_with "consul-k8s"
+
+  def install
+    bin.install "consul-k8s"
+  end
+
+  test do
+    system "#{bin}/consul-k8s --version"
+  end
+end

--- a/Formula/envconsul.rb
+++ b/Formula/envconsul.rb
@@ -1,4 +1,4 @@
-class EnvConsul < Formula
+class Envconsul < Formula
   desc "Env Consul"
   homepage "https://github.com/hashicorp/envconsul"
   version "0.12.0"

--- a/Formula/envconsul.rb
+++ b/Formula/envconsul.rb
@@ -1,42 +1,46 @@
 class EnvConsul < Formula
-    desc "Env Consul"
-    homepage "https://github.com/hashicorp/envconsul"
-    version "0.12.0"
-  
-    if OS.mac?
-      url "https://releases.hashicorp.com/envconsul/0.12.0/envconsul_0.12.0_darwin_amd64.zip"
-      sha256 "f54e6a65890913a174a00540875f0b09735479f283225c0b71e4ead4655bfb1f"
-    end
-  
-    if OS.mac? && Hardware::CPU.arm?
-      def caveats
-        <<~EOS
-          The darwin_arm64 architecture is not supported for this product
-          at this time, however we do plan to support this in the future. The
-          darwin_amd64 binary has been installed and may work in
-          compatibility mode, but it is not fully supported.
-        EOS
-      end
-    end
-  
-    if OS.linux? && Hardware::CPU.intel?
-      url "https://releases.hashicorp.com/envconsul/0.12.0/envconsul_0.12.0_linux_amd64.zip"
-      sha256 "0078233eefe9499ec047057f1a4c1bb781847da0f45959751a33acf613d2566f"
-    enda
-  
-    if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-      url "https://releases.hashicorp.com/envconsul/0.12.0/envconsul_0.12.0_linux_arm64.zip"
-      sha256 "0e4b9cfaf4346097eea4576d411fe155b71d280e633e57fb273b84c3683292d4"
-    end
-  
-    conflicts_with "envconsul"
-  
-    def install
-      bin.install "envconsul"
-    end
-  
-    test do
-      system "#{bin}/envconsul --version"
+  desc "Env Consul"
+  homepage "https://github.com/hashicorp/envconsul"
+  version "0.12.0"
+
+  if OS.mac?
+    url "https://releases.hashicorp.com/envconsul/0.12.0/envconsul_0.12.0_darwin_amd64.zip"
+    sha256 "f54e6a65890913a174a00540875f0b09735479f283225c0b71e4ead4655bfb1f"
+  end
+
+  if OS.mac? && Hardware::CPU.arm?
+    def caveats
+      <<~EOS
+        The darwin_arm64 architecture is not supported for this product
+        at this time, however we do plan to support this in the future. The
+        darwin_amd64 binary has been installed and may work in
+        compatibility mode, but it is not fully supported.
+      EOS
     end
   end
-  
+
+  if OS.linux? && Hardware::CPU.intel?
+    url "https://releases.hashicorp.com/envconsul/0.12.0/envconsul_0.12.0_linux_amd64.zip"
+    sha256 "0078233eefe9499ec047057f1a4c1bb781847da0f45959751a33acf613d2566f"
+  end
+
+  if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
+    url "https://releases.hashicorp.com/envconsul/0.12.0/envconsul_0.12.0_linux_arm.zip"
+    sha256 "a85bd7496c9daecf292a07103197177f139a8e2bac0162473b294b23f211ad56"
+  end
+
+  if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+    url "https://releases.hashicorp.com/envconsul/0.12.0/envconsul_0.12.0_linux_arm64.zip"
+    sha256 "0e4b9cfaf4346097eea4576d411fe155b71d280e633e57fb273b84c3683292d4"
+  end
+
+  conflicts_with "envconsul"
+
+  def install
+    bin.install "envconsul"
+  end
+
+  test do
+    system "#{bin}/envconsul --version"
+  end
+end

--- a/util/formula_templater/config.hcl
+++ b/util/formula_templater/config.hcl
@@ -61,7 +61,7 @@ EOF
 
 formula {
     product = "consul-aws"
-    name = "ConsulAWS"
+    name = "ConsulAws"
     desc = "Consul AWS"
     homepage = "https://github.com/hashicorp/consul-aws"
     architectures {
@@ -75,7 +75,7 @@ formula {
 
 formula {
     product = "consul-esm"
-    name = "ConsulESM"
+    name = "ConsulEsm"
     desc = "Consul ESM"
     homepage = "https://github.com/hashicorp/consul-esm"
     architectures {
@@ -131,7 +131,7 @@ formula {
 
 formula {
     product = "envconsul"
-    name = "EnvConsul"
+    name = "Envconsul"
     desc = "Env Consul"
     homepage = "https://github.com/hashicorp/envconsul"
     architectures {


### PR DESCRIPTION
Building on https://github.com/hashicorp/homebrew-tap/pull/159, homebrew doesn't like class names in the format `ConsulAWS` vs `ConsulAws`