### PR TITLE
Improve lambda trigger to look at product specific index

### DIFF
--- a/util/lambda_trigger/lambda_trigger_test.go
+++ b/util/lambda_trigger/lambda_trigger_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 const test_product = "nomad"
-const test_version = "1.1.2"
+const test_version = "1.2.6"
 
 func TestGetFormulaVersion(t *testing.T) {
 	gotLatest, err := getFormulaVersion(test_product)

--- a/util/lambda_trigger/releases.go
+++ b/util/lambda_trigger/releases.go
@@ -1,18 +1,17 @@
 package main
 
 import (
+	"fmt"
+
 	hb "github.com/gulducat/hashi-bin/types"
 )
 
 // ReleasesURL The url to read the releases index from
-const ReleasesURL = "https://hc-releases-prod.s3.amazonaws.com/index.json"
+const ReleasesURL = "https://hc-releases-prod.s3.amazonaws.com"
 
 func getLatestVersion(productName string) (*hb.Version, error) {
-	index, err := hb.NewIndex(ReleasesURL)
-	if err != nil {
-		return &hb.Version{}, err
-	}
-	product, err := index.GetProduct(productName)
+	url := fmt.Sprintf("%s/%s/%s", ReleasesURL, productName, "index.json")
+	product, err := hb.NewProduct(url)
 	if err != nil {
 		return &hb.Version{}, err
 	}

--- a/util/lambda_trigger/releases.go
+++ b/util/lambda_trigger/releases.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/url"
 
 	hb "github.com/gulducat/hashi-bin/types"
 )
@@ -10,7 +11,8 @@ import (
 const ReleasesURL = "https://hc-releases-prod.s3.amazonaws.com"
 
 func getLatestVersion(productName string) (*hb.Version, error) {
-	url := fmt.Sprintf("%s/%s/%s", ReleasesURL, productName, "index.json")
+	safeProduct := url.PathEscape(productName)
+	url := fmt.Sprintf("%s/%s/%s", ReleasesURL, safeProduct, "index.json")
 	product, err := hb.NewProduct(url)
 	if err != nil {
 		return &hb.Version{}, err


### PR DESCRIPTION
The existing lambda trigger to update formulae looks at the root releases index.json, which is a large file and may be slower to update than the product's own index.json.  Since we already know the product in this context, get the product specific index instead.