### PR TITLE
Add formula_templater bin to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+util/formula_templater/formula_templater
+


### PR DESCRIPTION
Just to prevent folks (like me) from accidentally picking up the formula_templater binary in a commit.