### PR TITLE
update s3 reference to new prod bucket

### DIFF
--- a/util/lambda_trigger/releases.go
+++ b/util/lambda_trigger/releases.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ReleasesURL The url to read the releases index from
-const ReleasesURL = "https://hc-releases-prod.s3.amazonaws.com"
+const ReleasesURL = "https://hc-publish-prod-artifacts.s3.amazonaws.com"
 
 func getLatestVersion(productName string) (*hb.Version, error) {
 	safeProduct := url.PathEscape(productName)

--- a/util/lambda_trigger/releases.go
+++ b/util/lambda_trigger/releases.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ReleasesURL The url to read the releases index from
-const ReleasesURL = "https://hc-publish-prod-artifacts.s3.amazonaws.com"
+const ReleasesURL = "https://releases.hashicorp.com"
 
 func getLatestVersion(productName string) (*hb.Version, error) {
 	safeProduct := url.PathEscape(productName)


### PR DESCRIPTION
We moved production artifacts to a new s3 bucket so this PR updates the URL accordingly. 