### PR TITLE
util: Enable terraform-ls publishing

### DIFF
--- a/util/formula_templater/config.hcl
+++ b/util/formula_templater/config.hcl
@@ -1,4 +1,3 @@
-
 formula {
     product = "boundary"
     name = "Boundary"
@@ -220,6 +219,20 @@ formula {
     name = "Terraform"
     desc = "Terraform"
     homepage = "https://www.terraform.io/"
+    architectures {
+        darwin_amd64 = true
+        darwin_arm64 = true
+        linux_amd64 = true
+        linux_arm = true
+        linux_arm64 = true
+    }
+}
+
+formula {
+    product = "terraform-ls"
+    name = "TerraformLs"
+    desc = "Terraform Language Server"
+    homepage = "https://github.com/hashicorp/terraform-ls"
     architectures {
         darwin_amd64 = true
         darwin_arm64 = true

--- a/util/lambda_trigger/lambda_trigger.go
+++ b/util/lambda_trigger/lambda_trigger.go
@@ -37,6 +37,7 @@ func isProductSupported(product string) bool {
 		"nomad",
 		"nomad-pack",
 		"terraform",
+		"terraform-ls",
 		"packer",
 		"boundary",
 		"waypoint",

--- a/util/lambda_trigger/lambda_trigger_test.go
+++ b/util/lambda_trigger/lambda_trigger_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 const test_product = "nomad"
-const test_version = "1.2.6"
+const test_version = "1.3.1"
 
 func TestGetFormulaVersion(t *testing.T) {
 	gotLatest, err := getFormulaVersion(test_product)


### PR DESCRIPTION
Previously terraform-ls homebrew formula was published via GoReleaser.

https://github.com/hashicorp/terraform-ls/pull/942 is disabling that publishing within GoReleaser and this PR is enabling it here, so the two should not conflict and this should better align the project with the rest of the release pipeline.