### PR TITLE
Add consul-dataplane formula

### DIFF
--- a/Formula/consul-dataplane.rb
+++ b/Formula/consul-dataplane.rb
@@ -1,33 +1,33 @@
 class ConsulDataplane < Formula
   desc "Consul Dataplane"
   homepage "https://github.com/hashicorp/consul-dataplane"
-  version "0.1.0-beta"
+  version "1.0.0-beta1"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul-dataplane/0.1.0-beta/consul-dataplane_0.1.0-beta_darwin_amd64.zip"
+    url "https://releases.hashicorp.com/consul-dataplane/1.0.0-beta1/consul-dataplane_1.0.0-beta1_darwin_amd64.zip"
     sha256 ""
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/consul-dataplane/0.1.0-beta/consul-dataplane_0.1.0-beta_darwin_arm64.zip"
+    url "https://releases.hashicorp.com/consul-dataplane/1.0.0-beta1/consul-dataplane_1.0.0-beta1_darwin_arm64.zip"
     sha256 ""
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul-dataplane/0.1.0-beta/consul-dataplane_0.1.0-beta_linux_amd64.zip"
+    url "https://releases.hashicorp.com/consul-dataplane/1.0.0-beta1/consul-dataplane_1.0.0-beta1_linux_amd64.zip"
     sha256 ""
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul-dataplane/0.1.0-beta/consul-dataplane_0.1.0-beta_linux_arm.zip"
+    url "https://releases.hashicorp.com/consul-dataplane/1.0.0-beta1/consul-dataplane_1.0.0-beta1_linux_arm.zip"
     sha256 ""
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul-dataplane/0.1.0-beta/consul-dataplane_0.1.0-beta_linux_arm64.zip"
+    url "https://releases.hashicorp.com/consul-dataplane/1.0.0-beta1/consul-dataplane_1.0.0-beta1_linux_arm64.zip"
     sha256 ""
   end
-  
+
   depends_on "envoy" => :recommended
 
   conflicts_with "consul-dataplane"

--- a/Formula/consul-dataplane.rb
+++ b/Formula/consul-dataplane.rb
@@ -5,29 +5,29 @@ class ConsulDataplane < Formula
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://releases.hashicorp.com/consul-dataplane/1.0.0-beta1/consul-dataplane_1.0.0-beta1_darwin_amd64.zip"
-    sha256 ""
+    sha256 "fd647458644e93b829409d20d6d1063365eae42a50a0f58abd42e3972818eb9c"
   end
 
   if OS.mac? && Hardware::CPU.arm?
     url "https://releases.hashicorp.com/consul-dataplane/1.0.0-beta1/consul-dataplane_1.0.0-beta1_darwin_arm64.zip"
-    sha256 ""
+    sha256 "88c27265a221843fc27dfd89dc1cfc5de4599538124cadb8ad8d9e5f0a32d96c"
   end
 
   if OS.linux? && Hardware::CPU.intel?
     url "https://releases.hashicorp.com/consul-dataplane/1.0.0-beta1/consul-dataplane_1.0.0-beta1_linux_amd64.zip"
-    sha256 ""
+    sha256 "4d802c06413d6374461aae89bc2fc1d2b067088f4a4bb89672d573322658fdff"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
     url "https://releases.hashicorp.com/consul-dataplane/1.0.0-beta1/consul-dataplane_1.0.0-beta1_linux_arm.zip"
-    sha256 ""
+    sha256 "db8bb803ce94832e44e262a5a18633e3af2cb39118e5d5c71c5a70668540453a"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
     url "https://releases.hashicorp.com/consul-dataplane/1.0.0-beta1/consul-dataplane_1.0.0-beta1_linux_arm64.zip"
-    sha256 ""
+    sha256 "77e43779bb348da5b4d2e1b0ca476c17fe5ddf4b473cb885d30af81b05a94cc2"
   end
-
+  
   depends_on "envoy" => :recommended
 
   conflicts_with "consul-dataplane"

--- a/Formula/consul-dataplane.rb
+++ b/Formula/consul-dataplane.rb
@@ -1,0 +1,42 @@
+class ConsulDataplane < Formula
+  desc "Consul Dataplane"
+  homepage "https://github.com/hashicorp/consul-dataplane"
+  version "0.1.0-beta"
+
+  if OS.mac? && Hardware::CPU.intel?
+    url "https://releases.hashicorp.com/consul-dataplane/0.1.0-beta/consul-dataplane_0.1.0-beta_darwin_amd64.zip"
+    sha256 ""
+  end
+
+  if OS.mac? && Hardware::CPU.arm?
+    url "https://releases.hashicorp.com/consul-dataplane/0.1.0-beta/consul-dataplane_0.1.0-beta_darwin_arm64.zip"
+    sha256 ""
+  end
+
+  if OS.linux? && Hardware::CPU.intel?
+    url "https://releases.hashicorp.com/consul-dataplane/0.1.0-beta/consul-dataplane_0.1.0-beta_linux_amd64.zip"
+    sha256 ""
+  end
+
+  if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
+    url "https://releases.hashicorp.com/consul-dataplane/0.1.0-beta/consul-dataplane_0.1.0-beta_linux_arm.zip"
+    sha256 ""
+  end
+
+  if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+    url "https://releases.hashicorp.com/consul-dataplane/0.1.0-beta/consul-dataplane_0.1.0-beta_linux_arm64.zip"
+    sha256 ""
+  end
+  
+  depends_on "envoy" => :recommended
+
+  conflicts_with "consul-dataplane"
+
+  def install
+    bin.install "consul-dataplane"
+  end
+
+  test do
+    system "#{bin}/consul-dataplane --version"
+  end
+end

--- a/util/formula_templater/config.go
+++ b/util/formula_templater/config.go
@@ -20,6 +20,7 @@ type FormulaConfig struct {
 	Version       string
 	Architectures FormulaArchitectures `hcl:"architectures,block"`
 	Depends       []string             `hcl:"depends,optional"`
+	Recommends    []string             `hcl:"recommends,optional"`
 	Plist         string               `hcl:"plist,optional"`
 	PlistOptions  string               `hcl:"plist_options,optional"`
 	Cask          bool                 `hcl:"cask,optional"`

--- a/util/formula_templater/config.hcl
+++ b/util/formula_templater/config.hcl
@@ -73,6 +73,21 @@ formula {
 }
 
 formula {
+    product = "consul-dataplane"
+    name = "ConsulDataplane"
+    desc = "Consul Dataplane"
+    homepage = "https://github.com/hashicorp/consul-dataplane"
+    architectures {
+        darwin_amd64 = true
+        darwin_arm64 = true
+        linux_amd64 = true
+        linux_arm = true
+        linux_arm64 = true
+    }
+    recommends = ["envoy"]
+}
+
+formula {
     product = "consul-esm"
     name = "ConsulEsm"
     desc = "Consul ESM"

--- a/util/formula_templater/formula.go
+++ b/util/formula_templater/formula.go
@@ -125,6 +125,12 @@ const formulaTemplate = `class {{ .Name }} < Formula
   {{- end }}
   {{- end}}
 
+  {{- with .Recommends }}
+  {{ range $index, $element := . }}
+  depends_on "{{ . }}" => :recommended
+  {{- end }}
+  {{- end}}
+
   conflicts_with "{{ .Product }}"
 
   def install

--- a/util/lambda_trigger/lambda_trigger.go
+++ b/util/lambda_trigger/lambda_trigger.go
@@ -27,6 +27,7 @@ func isProductSupported(product string) bool {
 		"vault",
 		"consul",
 		"consul-aws",
+		"consul-dataplane",
 		"consul-esm",
 		"consul-k8s",
 		"consul-template",


### PR DESCRIPTION
Adds a formula for consul-dataplane. Should not be merged until the release artifacts are ready (note: the formula is missing checksums so will need to be regenerated).

Also adds support for "recommended" dependencies, as consul-dataplane requires Envoy but users may choose to build it themselves.