### PR TITLE
Add Support for our ENT products

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,9 @@
 automerge:
   - Formula/consul.rb
+  - Formula/consul-enterprise.rb
   - Formula/nomad.rb
+  - Formula/nomad-enterprise.rb
   - Formula/packer.rb
   - Formula/terraform.rb
   - Formula/vault.rb
+  - Formula/vault-enterprise.rb

--- a/Formula/consul-enterprise.rb
+++ b/Formula/consul-enterprise.rb
@@ -1,0 +1,76 @@
+class ConsulEnterprise < Formula
+  desc "Consul Enterprise"
+  homepage "https://www.consul.io"
+  version "1.13.2+ent"
+
+  if OS.mac? && Hardware::CPU.intel?
+    url "https://releases.hashicorp.com/consul/1.13.2+ent/consul_1.13.2+ent_darwin_amd64.zip"
+    sha256 "23e6194bea0c7024d507c5339db4c41e53d6200eae3618d96dc2dd3858ad8357"
+  end
+
+  if OS.mac? && Hardware::CPU.arm?
+    url "https://releases.hashicorp.com/consul/1.13.2+ent/consul_1.13.2+ent_darwin_arm64.zip"
+    sha256 "08d007e82b3ce669bffef522f15c93b598d6e1d416b1b61504d66ec3ef14fa31"
+  end
+
+  if OS.linux? && Hardware::CPU.intel?
+    url "https://releases.hashicorp.com/consul/1.13.2+ent/consul_1.13.2+ent_linux_amd64.zip"
+    sha256 "5442ab15f7374c3488d5ea06a8fb72b97a19a0096b6fc587c7608387e28ab01d"
+  end
+
+  if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
+    url "https://releases.hashicorp.com/consul/1.13.2+ent/consul_1.13.2+ent_linux_arm.zip"
+    sha256 "b29f186f4ca3a33b6851da74455daa94308404bcbecbd95087b1cc5f95267711"
+  end
+
+  if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+    url "https://releases.hashicorp.com/consul/1.13.2+ent/consul_1.13.2+ent_linux_arm64.zip"
+    sha256 "cb76403a31ecec5e945b56d91aed71f1fad0ee68102a4afead2f0c42274374d5"
+  end
+
+  conflicts_with "consul-enterprise"
+
+  def install
+    bin.install "consul"
+  end
+
+  plist_options manual: "consul agent -dev -bind 127.0.0.1"
+
+  def plist; <<~EOS
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+    <key>Label</key>
+    <string>#{plist_name}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>#{opt_bin}/consul</string>
+        <string>agent</string>
+        <string>-dev</string>
+        <string>-bind</string>
+        <string>127.0.0.1</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>WorkingDirectory</key>
+    <string>#{var}</string>
+    <key>StandardErrorPath</key>
+    <string>#{var}/log/consul.log</string>
+    <key>StandardOutPath</key>
+    <string>#{var}/log/consul.log</string>
+</dict>
+</plist>
+
+EOS
+  end
+
+  test do
+    system "#{bin}/consul --version"
+  end
+end

--- a/Formula/nomad-enterprise.rb
+++ b/Formula/nomad-enterprise.rb
@@ -1,0 +1,74 @@
+class NomadEnterprise < Formula
+  desc "Nomad Enterprise"
+  homepage "https://www.nomadproject.io/"
+  version "1.3.5+ent"
+
+  if OS.mac? && Hardware::CPU.intel?
+    url "https://releases.hashicorp.com/nomad/1.3.5+ent/nomad_1.3.5+ent_darwin_amd64.zip"
+    sha256 "098a48d43a8b3f9d99483e050585790584e8480b9c36d862ef3ec25a04771fa4"
+  end
+
+  if OS.mac? && Hardware::CPU.arm?
+    url "https://releases.hashicorp.com/nomad/1.3.5+ent/nomad_1.3.5+ent_darwin_arm64.zip"
+    sha256 "a14fd62aed34e06f14421a99e19b668d80f7868af57c8b3f59dae4177e2a6300"
+  end
+
+  if OS.linux? && Hardware::CPU.intel?
+    url "https://releases.hashicorp.com/nomad/1.3.5+ent/nomad_1.3.5+ent_linux_amd64.zip"
+    sha256 "cd41ff13ff417a7a449ede4e5fbf02613c9e7f497f5657d866e926455fa88e9d"
+  end
+
+  if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
+    url "https://releases.hashicorp.com/nomad/1.3.5+ent/nomad_1.3.5+ent_linux_arm.zip"
+    sha256 "23be6d1f4902893e64e21b30d9d8c7f483a57f81f2377513ecc91eec541c6f9c"
+  end
+
+  if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+    url "https://releases.hashicorp.com/nomad/1.3.5+ent/nomad_1.3.5+ent_linux_arm64.zip"
+    sha256 "c682566a208e78a780d6e0bf8518629e4d3cb3d7fcdf6d9657e76f1d577fda3b"
+  end
+
+  conflicts_with "nomad-enterprise"
+
+  def install
+    bin.install "nomad"
+  end
+
+  plist_options manual: "nomad agent -dev"
+
+  def plist; <<~EOS
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+    <key>Label</key>
+    <string>#{plist_name}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>#{opt_bin}/nomad</string>
+        <string>agent</string>
+        <string>-dev</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>WorkingDirectory</key>
+    <string>#{var}</string>
+    <key>StandardErrorPath</key>
+    <string>#{var}/log/nomad.log</string>
+    <key>StandardOutPath</key>
+    <string>#{var}/log/nomad.log</string>
+</dict>
+</plist>
+
+EOS
+  end
+
+  test do
+    system "#{bin}/nomad --version"
+  end
+end

--- a/Formula/vault-enterprise.rb
+++ b/Formula/vault-enterprise.rb
@@ -1,0 +1,74 @@
+class VaultEnterprise < Formula
+  desc "Vault Enterprise"
+  homepage "https://www.vaultproject.io"
+  version "1.11.3+ent"
+
+  if OS.mac? && Hardware::CPU.intel?
+    url "https://releases.hashicorp.com/vault/1.11.3+ent/vault_1.11.3+ent_darwin_amd64.zip"
+    sha256 "71a8e350d0bc0f1cf346388d9958da54e9e2be0f5cc1a8753cbd4700baa68119"
+  end
+
+  if OS.mac? && Hardware::CPU.arm?
+    url "https://releases.hashicorp.com/vault/1.11.3+ent/vault_1.11.3+ent_darwin_arm64.zip"
+    sha256 "4aaafc06d9e6da942d63f3347b2a329361b62e84ec295e3fcaf6a1c608419cdb"
+  end
+
+  if OS.linux? && Hardware::CPU.intel?
+    url "https://releases.hashicorp.com/vault/1.11.3+ent/vault_1.11.3+ent_linux_amd64.zip"
+    sha256 "1fba33d24170081696a8684bc55291ece3eae48943c20aa4de2c999515691ccf"
+  end
+
+  if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
+    url "https://releases.hashicorp.com/vault/1.11.3+ent/vault_1.11.3+ent_linux_arm.zip"
+    sha256 "f45d2164d4941d069e916e35d339748a7cc4ec84f63688fe5203bf7c1e33747f"
+  end
+
+  if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+    url "https://releases.hashicorp.com/vault/1.11.3+ent/vault_1.11.3+ent_linux_arm64.zip"
+    sha256 "e6dade7c8af7b09cc164d2f3195ee464dcb85d63a22d3bc13c92d3cc1e1de632"
+  end
+
+  conflicts_with "vault-enterprise"
+
+  def install
+    bin.install "vault"
+  end
+
+  plist_options manual: "vault server -dev"
+
+  def plist; <<~EOS
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+    <key>Label</key>
+    <string>#{plist_name}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>#{opt_bin}/vault</string>
+        <string>server</string>
+        <string>-dev</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>WorkingDirectory</key>
+    <string>#{var}</string>
+    <key>StandardErrorPath</key>
+    <string>#{var}/log/vault.log</string>
+    <key>StandardOutPath</key>
+    <string>#{var}/log/vault.log</string>
+</dict>
+</plist>
+
+EOS
+  end
+
+  test do
+    system "#{bin}/vault --version"
+  end
+end

--- a/README.md
+++ b/README.md
@@ -42,17 +42,20 @@ With the following commands, you can install the latest generally available (GA)
 # Formulae
 brew install hashicorp/tap/boundary
 brew install hashicorp/tap/consul
+brew install hashicorp/tap/consul-enterprise
 brew install hashicorp/tap/consul-template
 brew install hashicorp/tap/consul-terraform-sync
 brew install hashicorp/tap/hcdiag
 brew install hashicorp/tap/levant
 brew install hashicorp/tap/nomad
+brew install hashicorp/tap/nomad-enterprise
 brew install hashicorp/tap/nomad-pack
 brew install hashicorp/tap/packer
 brew install hashicorp/tap/sentinel
 brew install hashicorp/tap/terraform
 brew install hashicorp/tap/terraform-ls
 brew install hashicorp/tap/vault
+brew install hashicorp/tap/vault-enterprise
 brew install hashicorp/tap/waypoint
 
 # Casks

--- a/util/formula_templater/config.go
+++ b/util/formula_templater/config.go
@@ -14,6 +14,7 @@ type Config struct {
 // FormulaConfig all required formula data
 type FormulaConfig struct {
 	Product       string `hcl:"product"`
+	Variant       string `hcl:"variant,optional"`
 	Name          string `hcl:"name"`
 	Desc          string `hcl:"desc"`
 	Homepage      string `hcl:"homepage"`

--- a/util/formula_templater/config.hcl
+++ b/util/formula_templater/config.hcl
@@ -59,6 +59,52 @@ EOF
 }
 
 formula {
+    product = "consul-enterprise"
+    name = "ConsulEnterprise"
+    desc = "Consul Enterprise"
+    homepage = "https://www.consul.io"
+    architectures {
+        darwin_amd64 = true
+        darwin_arm64 = true
+        linux_amd64 = true
+        linux_arm = true
+        linux_arm64 = true
+    }
+    plist =<<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+    <key>Label</key>
+    <string>#{plist_name}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>#{opt_bin}/consul</string>
+        <string>agent</string>
+        <string>-dev</string>
+        <string>-bind</string>
+        <string>127.0.0.1</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>WorkingDirectory</key>
+    <string>#{var}</string>
+    <key>StandardErrorPath</key>
+    <string>#{var}/log/consul.log</string>
+    <key>StandardOutPath</key>
+    <string>#{var}/log/consul.log</string>
+</dict>
+</plist>
+EOF
+    plist_options = "consul agent -dev -bind 127.0.0.1"
+}
+
+formula {
     product = "consul-aws"
     name = "ConsulAws"
     desc = "Consul AWS"
@@ -201,6 +247,50 @@ EOF
 }
 
 formula {
+    product = "nomad-enterprise"
+    name = "NomadEnterprise"
+    desc = "Nomad Enterprise"
+    homepage = "https://www.nomadproject.io/"
+    architectures {
+        darwin_amd64 = true
+        darwin_arm64 = true
+        linux_amd64 = true
+        linux_arm = true
+        linux_arm64 = true
+    }
+    plist =<<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+    <key>Label</key>
+    <string>#{plist_name}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>#{opt_bin}/nomad</string>
+        <string>agent</string>
+        <string>-dev</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>WorkingDirectory</key>
+    <string>#{var}</string>
+    <key>StandardErrorPath</key>
+    <string>#{var}/log/nomad.log</string>
+    <key>StandardOutPath</key>
+    <string>#{var}/log/nomad.log</string>
+</dict>
+</plist>
+EOF
+    plist_options = "nomad agent -dev"
+}
+
+formula {
     product = "packer"
     name = "Packer"
     desc = "Packer"
@@ -246,6 +336,50 @@ formula {
     product = "vault"
     name = "Vault"
     desc = "Vault"
+    homepage = "https://www.vaultproject.io"
+    architectures {
+        darwin_amd64 = true
+        darwin_arm64 = true
+        linux_amd64 = true
+        linux_arm = true
+        linux_arm64 = true
+    }
+    plist =<<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+    <key>Label</key>
+    <string>#{plist_name}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>#{opt_bin}/vault</string>
+        <string>server</string>
+        <string>-dev</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>WorkingDirectory</key>
+    <string>#{var}</string>
+    <key>StandardErrorPath</key>
+    <string>#{var}/log/vault.log</string>
+    <key>StandardOutPath</key>
+    <string>#{var}/log/vault.log</string>
+</dict>
+</plist>
+EOF
+    plist_options = "vault server -dev"
+}
+
+formula {
+    product = "vault-enterprise"
+    name = "VaultEnterprise"
+    desc = "Vault Enterprise"
     homepage = "https://www.vaultproject.io"
     architectures {
         darwin_amd64 = true

--- a/util/formula_templater/formula.go
+++ b/util/formula_templater/formula.go
@@ -139,7 +139,7 @@ const formulaTemplate = `class {{ .Name }} < Formula
 
   conflicts_with "{{ .Product }}-{{ .Variant }}"
   {{- else }}
-  
+
   conflicts_with "{{ .Product }}"
   {{- end }}
 

--- a/util/formula_templater/formula.go
+++ b/util/formula_templater/formula.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"strings"
 	"text/template"
 )
 
@@ -54,6 +55,15 @@ func printFormula(product string, version string, configLocation string, out io.
 		if productConfig.Architectures.LinuxArm64 {
 			sha := getShasum(shasums, product, version, "linux_arm64")
 			productConfig.Architectures.LinuxArm64SHA = sha
+		}
+
+		// For enterprise products only, set a Variant variable to 'enterprise'
+		// and update the product name to be the base product without the variant
+		// e.g. product name will be 'vault' instead of 'vault-enterprise
+		// This is needed to produce the right Formula.rb files for ENT products
+		if strings.HasSuffix(strings.ToLower(productConfig.Product), "-enterprise") {
+			productConfig.Variant = "enterprise"
+			productConfig.Product = strings.TrimSuffix(productConfig.Product, "-enterprise")
 		}
 
 		t = template.Must(template.New("formula").Parse(formulaTemplate))
@@ -125,7 +135,13 @@ const formulaTemplate = `class {{ .Name }} < Formula
   {{- end }}
   {{- end}}
 
+  {{- if .Variant }}
+
+  conflicts_with "{{ .Product }}-{{ .Variant }}"
+  {{- else }}
+  
   conflicts_with "{{ .Product }}"
+  {{- end }}
 
   def install
     bin.install "{{ .Product }}"

--- a/util/formula_templater/formula_test.go
+++ b/util/formula_templater/formula_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPrintFormula(t *testing.T) {
+func TestPrintOSSFormula(t *testing.T) {
 	product := "consul"
 	version := "1.9.4"
 	config := "./config.hcl"
@@ -43,8 +43,96 @@ func TestPrintFormula(t *testing.T) {
     url "https://releases.hashicorp.com/consul/1.9.4/consul_1.9.4_linux_arm64.zip"
     sha256 "012c552aff502f907416c9a119d2dfed88b92e981f9b160eb4fe292676afdaeb"
   end
-
+  
   conflicts_with "consul"
+
+  def install
+    bin.install "consul"
+  end
+
+  plist_options manual: "consul agent -dev -bind 127.0.0.1"
+
+  def plist; <<~EOS
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+    <key>Label</key>
+    <string>#{plist_name}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>#{opt_bin}/consul</string>
+        <string>agent</string>
+        <string>-dev</string>
+        <string>-bind</string>
+        <string>127.0.0.1</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>WorkingDirectory</key>
+    <string>#{var}</string>
+    <key>StandardErrorPath</key>
+    <string>#{var}/log/consul.log</string>
+    <key>StandardOutPath</key>
+    <string>#{var}/log/consul.log</string>
+</dict>
+</plist>
+
+EOS
+  end
+
+  test do
+    system "#{bin}/consul --version"
+  end
+end
+`
+
+	err := printFormula(product, version, config, buf)
+	require.Nil(t, err)
+	assert.Equal(t, expect, buf.String())
+}
+
+func TestPrintENTFormula(t *testing.T) {
+	product := "consul-enterprise"
+	version := "1.13.2+ent"
+	config := "./config.hcl"
+	buf := new(bytes.Buffer)
+	expect := `class ConsulEnterprise < Formula
+  desc "Consul Enterprise"
+  homepage "https://www.consul.io"
+  version "1.13.2+ent"
+
+  if OS.mac? && Hardware::CPU.intel?
+    url "https://releases.hashicorp.com/consul/1.13.2+ent/consul_1.13.2+ent_darwin_amd64.zip"
+    sha256 "23e6194bea0c7024d507c5339db4c41e53d6200eae3618d96dc2dd3858ad8357"
+  end
+
+  if OS.mac? && Hardware::CPU.arm?
+    url "https://releases.hashicorp.com/consul/1.13.2+ent/consul_1.13.2+ent_darwin_arm64.zip"
+    sha256 "08d007e82b3ce669bffef522f15c93b598d6e1d416b1b61504d66ec3ef14fa31"
+  end
+
+  if OS.linux? && Hardware::CPU.intel?
+    url "https://releases.hashicorp.com/consul/1.13.2+ent/consul_1.13.2+ent_linux_amd64.zip"
+    sha256 "5442ab15f7374c3488d5ea06a8fb72b97a19a0096b6fc587c7608387e28ab01d"
+  end
+
+  if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
+    url "https://releases.hashicorp.com/consul/1.13.2+ent/consul_1.13.2+ent_linux_arm.zip"
+    sha256 "b29f186f4ca3a33b6851da74455daa94308404bcbecbd95087b1cc5f95267711"
+  end
+
+  if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+    url "https://releases.hashicorp.com/consul/1.13.2+ent/consul_1.13.2+ent_linux_arm64.zip"
+    sha256 "cb76403a31ecec5e945b56d91aed71f1fad0ee68102a4afead2f0c42274374d5"
+  end
+
+  conflicts_with "consul-enterprise"
 
   def install
     bin.install "consul"

--- a/util/formula_templater/formula_test.go
+++ b/util/formula_templater/formula_test.go
@@ -43,7 +43,7 @@ func TestPrintOSSFormula(t *testing.T) {
     url "https://releases.hashicorp.com/consul/1.9.4/consul_1.9.4_linux_arm64.zip"
     sha256 "012c552aff502f907416c9a119d2dfed88b92e981f9b160eb4fe292676afdaeb"
   end
-  
+
   conflicts_with "consul"
 
   def install

--- a/util/formula_templater/shasums.go
+++ b/util/formula_templater/shasums.go
@@ -7,7 +7,19 @@ import (
 	"strings"
 )
 
+// For enterprise products, remove the "-enterprise" suffix
+// from the product name so that we can successfully get the SHASUMS
+// e.g. product name will be 'vault' instead of 'vault-enterprise'
+// For non-enterprise products, return the product name as-is
+func returnProduct(product string) string {
+	if strings.HasSuffix(strings.ToLower(product), "-enterprise") {
+		product = strings.TrimSuffix(product, "-enterprise")
+	}
+	return product
+}
+
 func loadShasums(product string, version string) (map[string]string, error) {
+	product = returnProduct(product)
 	shasums := make(map[string]string)
 	shasumURL := fmt.Sprintf("https://releases.hashicorp.com/%s/%s/%s_%s_SHA256SUMS", product, version, product, version)
 	resp, err := http.Get(shasumURL)
@@ -33,6 +45,7 @@ func loadShasums(product string, version string) (map[string]string, error) {
 }
 
 func getShasum(shasums map[string]string, product string, version string, arch string) string {
+	product = returnProduct(product)
 	zip := fmt.Sprintf("%s_%s_%s.zip", product, version, arch)
 	return shasums[zip]
 }

--- a/util/lambda_trigger/lambda_trigger.go
+++ b/util/lambda_trigger/lambda_trigger.go
@@ -25,7 +25,9 @@ type ReleaseEvent struct {
 func isProductSupported(product string) bool {
 	supportedProducts := []string{
 		"vault",
+		"vault-enterprise",
 		"consul",
+		"consul-enterprise",
 		"consul-aws",
 		"consul-esm",
 		"consul-k8s",
@@ -35,6 +37,7 @@ func isProductSupported(product string) bool {
 		"hcdiag",
 		"levant",
 		"nomad",
+		"nomad-enterprise",
 		"nomad-pack",
 		"terraform",
 		"terraform-ls",

--- a/util/lambda_trigger/lambda_trigger_test.go
+++ b/util/lambda_trigger/lambda_trigger_test.go
@@ -26,6 +26,9 @@ func TestOSSGetLatestVersion(t *testing.T) {
 	assert.Equal(t, test_oss_version, gotLatest.Version)
 }
 
+// These ENT tests will fail until
+// the ENT products are made available at
+// https://raw.githubusercontent.com/hashicorp/homebrew-tap/master/Formula/$ENT_PRODUCT_NAME.rb
 func TestENTGetFormulaVersion(t *testing.T) {
 	gotLatest, err := getFormulaVersion(test_ent_product)
 

--- a/util/lambda_trigger/lambda_trigger_test.go
+++ b/util/lambda_trigger/lambda_trigger_test.go
@@ -7,19 +7,35 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const test_product = "nomad"
-const test_version = "1.3.1"
+const test_oss_product = "nomad"
+const test_ent_product = "nomad-enterprise"
+const test_oss_version = "1.3.5"
+const test_ent_version = "1.3.5+ent"
 
-func TestGetFormulaVersion(t *testing.T) {
-	gotLatest, err := getFormulaVersion(test_product)
+func TestOSSGetFormulaVersion(t *testing.T) {
+	gotLatest, err := getFormulaVersion(test_oss_product)
 
 	require.Nil(t, err)
-	assert.Equal(t, test_version, gotLatest)
+	assert.Equal(t, test_oss_version, gotLatest)
 }
 
-func TestGetLatestVersion(t *testing.T) {
-	gotLatest, err := getLatestVersion(test_product)
+func TestOSSGetLatestVersion(t *testing.T) {
+	gotLatest, err := getLatestVersion(test_oss_product)
 
 	require.Nil(t, err)
-	assert.Equal(t, test_version, gotLatest.Version)
+	assert.Equal(t, test_oss_version, gotLatest.Version)
+}
+
+func TestENTGetFormulaVersion(t *testing.T) {
+	gotLatest, err := getFormulaVersion(test_ent_product)
+
+	require.Nil(t, err)
+	assert.Equal(t, test_ent_version, gotLatest)
+}
+
+func TestENTGetLatestVersion(t *testing.T) {
+	gotLatest, err := getLatestVersion(test_ent_product)
+
+	require.Nil(t, err)
+	assert.Equal(t, test_ent_version, gotLatest.Version)
 }


### PR DESCRIPTION
This PR adds support for our enterprise products to the official homebrew tap. Since our enterprise products are only supported via Formula's and not Casks, no changes were made to support enterprise Casks. If/when this is needed, we'll need to make further changes. 

A few changes needed to be made to the Formula templater in formula.go,  and in the function that grabs the SHASUMS from the releases site and injects them into the ruby templates. These are needed to conform with the URL's we have at releases.hashicorp.com for enterprise products. Beyond these changes, I just followed the steps outlined in the [linux and repos and homebrew docs](https://hashicorp.atlassian.net/wiki/spaces/ENSV/pages/2157904030/Linux+Repos+and+Homebrew#Add-New-Product-Support) to create the configs for the 'new' products and update the associated references. 

**For local testing**

Clone the repo and checkout this branch, cd into `homebrew-tap/util/formula_templater` and run `go build`. You can then run the templater with the product name and version inputs. Here is an example for the latest version of consul-enterprise: `./formula_templater consul-enterprise 1.13.2+ent config.hcl > ../../Formula/consul-enterprise.rb`. Running this will create the file  `../../Formula/consul-enterprise.rb`. 

You can also run the templater on non-enterprise products to ensure those haven't changed at all (since they are not expected to change with these additions!), e.g. `./formula_templater consul 1.13.2 config.hcl > ../../Formula/consul.rb`. This is expected to result in a no-op which you can verify by running `git diff -- ../../Formula/consul.rb`. 

**Post merge todos**

- Remember to deploy the lambda!!!!
- Check this repo to make sure the version bump automation was triggered and succeeded after merging the PR
- Follow the install instructions locally to ensure you can successfully install `consul-enterprise`, vault-ent, and nomad-ent, get the proper version string, etc. 
- Merge in docs updates on the dev portal: https://github.com/hashicorp/dev-portal/pull/1079, https://github.com/hashicorp/dev-portal/pull/1076