### PR TITLE
Fix lambda trigger for ENT

### DIFF
--- a/util/lambda_trigger/go.mod
+++ b/util/lambda_trigger/go.mod
@@ -5,5 +5,6 @@ go 1.14
 require (
 	github.com/aws/aws-lambda-go v1.19.1
 	github.com/gulducat/hashi-bin v1.0.2
+	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/stretchr/testify v1.6.1
 )

--- a/util/lambda_trigger/go.sum
+++ b/util/lambda_trigger/go.sum
@@ -19,6 +19,8 @@ github.com/hashicorp/go-hclog v0.10.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-version v1.2.0 h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+dIzX/E=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
+github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/util/lambda_trigger/lambda_trigger.go
+++ b/util/lambda_trigger/lambda_trigger.go
@@ -141,8 +141,7 @@ func HandleLambdaEvent(snsEvent events.SNSEvent) error {
 			if err != nil {
 				return err
 			}
-			fmt.Printf("Latest version is %s\n", version)
-			event.Version = version.Version
+			event.Version = *version
 			oldVersion := ""
 			event.Cask = isCask(event.Product)
 

--- a/util/lambda_trigger/lambda_trigger_test.go
+++ b/util/lambda_trigger/lambda_trigger_test.go
@@ -23,12 +23,9 @@ func TestOSSGetLatestVersion(t *testing.T) {
 	gotLatest, err := getLatestVersion(test_oss_product)
 
 	require.Nil(t, err)
-	assert.Equal(t, test_oss_version, gotLatest.Version)
+	assert.Equal(t, test_oss_version, *gotLatest)
 }
 
-// These ENT tests will fail until
-// the ENT products are made available at
-// https://raw.githubusercontent.com/hashicorp/homebrew-tap/master/Formula/$ENT_PRODUCT_NAME.rb
 func TestENTGetFormulaVersion(t *testing.T) {
 	gotLatest, err := getFormulaVersion(test_ent_product)
 
@@ -40,5 +37,5 @@ func TestENTGetLatestVersion(t *testing.T) {
 	gotLatest, err := getLatestVersion(test_ent_product)
 
 	require.Nil(t, err)
-	assert.Equal(t, test_ent_version, gotLatest.Version)
+	assert.Equal(t, test_ent_version, *gotLatest)
 }

--- a/util/lambda_trigger/releases.go
+++ b/util/lambda_trigger/releases.go
@@ -1,21 +1,56 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
-	"net/url"
-
-	hb "github.com/gulducat/hashi-bin/types"
+	"log"
+	"net/http"
+	"strings"
 )
 
-// ReleasesURL The url to read the releases index from
-const ReleasesURL = "https://releases.hashicorp.com"
+type ReleaseResponse Release
 
-func getLatestVersion(productName string) (*hb.Version, error) {
-	safeProduct := url.PathEscape(productName)
-	url := fmt.Sprintf("%s/%s/%s", ReleasesURL, safeProduct, "index.json")
-	product, err := hb.NewProduct(url)
-	if err != nil {
-		return &hb.Version{}, err
+type Release struct {
+	Version string
+}
+
+func releasesAPIRequest(apiBaseURL, productName string, license_class string) (*string, error) {
+	release := ReleaseResponse{}
+	url := fmt.Sprintf("%s/%s/latest", apiBaseURL, productName)
+	// For ENT, get the enterprise versions of the product
+	fmt.Printf("%v", license_class)
+	if license_class == "enterprise" {
+		productName = strings.TrimSuffix(productName, "-enterprise")
+		url = fmt.Sprintf("%s/%s/latest?license_class=enterprise", apiBaseURL, productName)
 	}
-	return product.LatestVersion(), nil
+
+	log.Printf("Reading %s", url)
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, err
+	}
+
+	return &release.Version, nil
+}
+
+func getLatestVersion(productName string) (*string, error) {
+	baseURL := "https://api.releases.hashicorp.com/v1/releases"
+	// Set `license_class` to ent for ENT products
+	// since that is required in the releases API call to get latest
+	license_class := "oss"
+	if strings.HasSuffix(strings.ToLower(productName), "-enterprise") {
+		license_class = "enterprise"
+	}
+	release, err := releasesAPIRequest(baseURL, productName, license_class)
+	// log.Printf("PRODUCT %v", product)
+	if err != nil {
+		return nil, err
+	}
+
+	return release, nil
 }


### PR DESCRIPTION
This is a fix-forward of https://github.com/hashicorp/homebrew-tap/pull/181, where we introduced packaging for ENT products. The lambda trigger that bumps the version when a new product is released needed to be updated. The tests are now passing and the logs look good, but we haven't had a new ent release to fully test this out yet. 

I already deployed this lambda, and will monitor it tomorrow to make sure it's ✅ 