### PR TITLE
Fixed vault Formula

### DIFF
--- a/Formula/vault.rb
+++ b/Formula/vault.rb
@@ -34,38 +34,12 @@ class Vault < Formula
     bin.install "vault"
   end
 
-  plist_options manual: "vault server -dev"
-
-  def plist; <<~EOS
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>KeepAlive</key>
-    <dict>
-        <key>SuccessfulExit</key>
-        <false/>
-    </dict>
-    <key>Label</key>
-    <string>#{plist_name}</string>
-    <key>ProgramArguments</key>
-    <array>
-        <string>#{opt_bin}/vault</string>
-        <string>server</string>
-        <string>-dev</string>
-    </array>
-    <key>RunAtLoad</key>
-    <true/>
-    <key>WorkingDirectory</key>
-    <string>#{var}</string>
-    <key>StandardErrorPath</key>
-    <string>#{var}/log/vault.log</string>
-    <key>StandardOutPath</key>
-    <string>#{var}/log/vault.log</string>
-</dict>
-</plist>
-
-EOS
+  service do
+    run [bin/"vault", "server", "-dev"]
+    keep_alive true
+    working_dir var
+    log_path var/"log/vault.log"
+    error_log_path var/"log/vault.log"
   end
 
   test do


### PR DESCRIPTION
Currently when installing we get a warning:
```
Warning: Calling plist_options is deprecated! Use service.require_root instead.
Please report this issue to the hashicorp/tap tap (not Homebrew/brew or Homebrew/homebrew-core), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/hashicorp/homebrew-tap/Formula/vault.rb:37
```
This fix removs this warning