### PR TITLE
update vault.rb for fix homebrew's warning

### DIFF
--- a/Formula/vault.rb
+++ b/Formula/vault.rb
@@ -34,7 +34,7 @@ class Vault < Formula
     bin.install "vault"
   end
 
-  plist_options manual: "vault server -dev"
+  service.require_root manual: "vault server -dev"
 
   def plist; <<~EOS
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
fix warning from home brew:
```
Warning: Calling plist_options is deprecated! Use service.require_root instead.
Please report this issue to the hashicorp/tap tap (not Homebrew/brew or Homebrew/homebrew-core), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/hashicorp/homebrew-tap/Formula/vault.rb:37

```
```

#  plist_options manual: "vault server -dev"
  service.require_root manual: "vault server -dev"
```