### PR TITLE
Log product info in run name

### DIFF
--- a/.github/workflows/publish-formula-update.yml
+++ b/.github/workflows/publish-formula-update.yml
@@ -1,4 +1,5 @@
 name: Update Product Formula in Tap
+run-name: Update ${{ github.event.client_payload.name }} to ${{ github.event.client_payload.version }}
 # This workflow will automatically update our product formulae on the release of
 # new versions
 on:


### PR DESCRIPTION
This is a QoL improvement to be able to distinguish between run without needing to dig into individual workflows. This also allows us to determine what product needs action should a workflow fail before it gets to the bump step. 