### PR TITLE
Restore the levant.rb SHASUMS update from #218

### DIFF
--- a/Formula/levant.rb
+++ b/Formula/levant.rb
@@ -5,7 +5,7 @@ class Levant < Formula
 
   if OS.mac?
     url "https://releases.hashicorp.com/levant/0.3.2/levant_0.3.2_darwin_amd64.zip"
-    sha256 "e75b24fa4b1fab25ebb30776e7e02b56ae173d06e77ff8a7bec7354daa459c0c"
+    sha256 "7406a9f089227254f3ed7eb4f67d22dc28c44b41f2233391b5f0d3ffa1be861e"
   end
 
   if OS.mac? && Hardware::CPU.arm?


### PR DESCRIPTION
## context 

in #218 this file was added but seems to have had an extra `cd` on the [filename `levant.rbcd`](https://github.com/hashicorp/homebrew-tap/pull/218/commits/b591f32d704840ab6e41329ebf3f441092802c45) and then [subsequently deleted](https://github.com/hashicorp/homebrew-tap/pull/218/commits/66aa15ceec076fb32027f06e87dd8dcc7e26bf6c)

but, i think we actually do want this sha update? otherwise, i cannot install levant with homebrew due to SHASUM mismatch; it expects the old one, but the actual one doesn't match

```shell
bash-5.0$ brew update
Already up-to-date.
bash-5.0$ brew install hashicorp/tap/levant
==> Fetching hashicorp/tap/levant
==> Downloading https://releases.hashicorp.com/levant/0.3.2/levant_0.3.2_darwin_amd64.zip
Already downloaded: /Users/dgempesaw/Library/Caches/Homebrew/downloads/70e32d7e152e0fa53ab8fe8be1784ede1c3f9856576bc51861780a14fd2e4434--levant_0.3.2_darwin_amd64.zip
Error: levant: SHA256 mismatch
Expected: e75b24fa4b1fab25ebb30776e7e02b56ae173d06e77ff8a7bec7354daa459c0c
  Actual: 7406a9f089227254f3ed7eb4f67d22dc28c44b41f2233391b5f0d3ffa1be861e
    File: /Users/dgempesaw/Library/Caches/Homebrew/downloads/70e32d7e152e0fa53ab8fe8be1784ede1c3f9856576bc51861780a14fd2e4434--levant_0.3.2_darwin_amd64.zip
To retry an incomplete download, remove the file above.
bash-5.0$ 
```

## changes

i went to that deleted commit, clicked the `Raw` link in github, copied the entire contents, and put it in my fork :P the only change was that one SHA, the others in the file didn't change 🤷🏽 

idk if the other SHASUMS are correct as-is, or if they also need changes...