### PR TITLE
Refactor forumla_templater testdata

### DIFF
--- a/util/formula_templater/Makefile
+++ b/util/formula_templater/Makefile
@@ -17,3 +17,9 @@ build: *.go go.* mod-download
 clean:
 	rm -rvf formula_templater
 	
+
+# Note: These URLs are pinned to the urls used by the test. If updated, please be sure to update the test values too.
+.PHONY: testdata
+testdata:
+	curl --fail --silent 'https://raw.githubusercontent.com/hashicorp/homebrew-tap/105fae955b81ad8d864b511a3875911c66a58c29/Formula/consul.rb' --output testdata/consul.rb
+	curl --fail --silent 'https://raw.githubusercontent.com/hashicorp/homebrew-tap/105fae955b81ad8d864b511a3875911c66a58c29/Formula/consul-enterprise.rb' --output testdata/consul-enterprise.rb

--- a/util/formula_templater/formula_test.go
+++ b/util/formula_templater/formula_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,121 +10,29 @@ import (
 )
 
 func TestPrintOSSFormula(t *testing.T) {
+	expect, err := os.ReadFile("testdata/consul.rb")
+	require.NoError(t, err)
+
 	product := "consul"
-	version := "1.13.2"
+	version := "1.15.1"
 	config := "./config.hcl"
 	buf := new(bytes.Buffer)
-	expect := `class Consul < Formula
-  desc "Consul"
-  homepage "https://www.consul.io"
-  version "1.13.2"
 
-  if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul/1.13.2/consul_1.13.2_darwin_amd64.zip"
-    sha256 "c2214b99fab0752fcc988fdae2add0437287332ef6b1f647ecee13d880af29eb"
-  end
-
-  if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/consul/1.13.2/consul_1.13.2_darwin_arm64.zip"
-    sha256 "054af8ce69b643ea5748a9604aed0e6b87f6176f901184430ee225f022743e32"
-  end
-
-  if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul/1.13.2/consul_1.13.2_linux_amd64.zip"
-    sha256 "a72e88cbfec6c0fb3620cd58314ff0b42fc9d605a5192d6a568a417180f0b35f"
-  end
-
-  if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul/1.13.2/consul_1.13.2_linux_arm.zip"
-    sha256 "e507590c4d044bc50651a6a64c25a1d02fd94bd9aaa7f27f93865b750f32d735"
-  end
-
-  if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul/1.13.2/consul_1.13.2_linux_arm64.zip"
-    sha256 "f3c38df5abe515b29520ff72ef11f05013d8da25109da425b1b9e1df1f3c3cc6"
-  end
-
-  conflicts_with "consul"
-
-  def install
-    bin.install "consul"
-  end
-
-  service do
-    run [bin/"consul", "agent", "-dev", "-bind", "127.0.0.1"]
-    keep_alive successful_exit: false
-    working_dir var
-    log_path var/"log/consul.log"
-    error_log_path var/"log/consul.log"
-  end
-
-  test do
-    system "#{bin}/consul --version"
-  end
-end
-`
-
-	err := printFormula(product, version, config, buf)
-	require.Nil(t, err)
-	assert.Equal(t, expect, buf.String())
+	err = printFormula(product, version, config, buf)
+	require.NoError(t, err)
+	assert.Equal(t, string(expect), buf.String())
 }
 
 func TestPrintENTFormula(t *testing.T) {
+	expect, err := os.ReadFile("testdata/consul-enterprise.rb")
+	require.NoError(t, err)
+
 	product := "consul-enterprise"
-	version := "1.13.2+ent"
+	version := "1.15.1+ent"
 	config := "./config.hcl"
 	buf := new(bytes.Buffer)
-	expect := `class ConsulEnterprise < Formula
-  desc "Consul Enterprise"
-  homepage "https://www.consul.io"
-  version "1.13.2+ent"
 
-  if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul/1.13.2+ent/consul_1.13.2+ent_darwin_amd64.zip"
-    sha256 "ab58cc9dd3ff5fe82e468423e7a27bfa8d2b494980394d8685505d85e1a2b3e8"
-  end
-
-  if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/consul/1.13.2+ent/consul_1.13.2+ent_darwin_arm64.zip"
-    sha256 "01be28011910dc4f2efb3b347c40bfbc59d6b7d25641f3f0d2dfc767c76ab6b2"
-  end
-
-  if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul/1.13.2+ent/consul_1.13.2+ent_linux_amd64.zip"
-    sha256 "5442ab15f7374c3488d5ea06a8fb72b97a19a0096b6fc587c7608387e28ab01d"
-  end
-
-  if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul/1.13.2+ent/consul_1.13.2+ent_linux_arm.zip"
-    sha256 "b29f186f4ca3a33b6851da74455daa94308404bcbecbd95087b1cc5f95267711"
-  end
-
-  if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul/1.13.2+ent/consul_1.13.2+ent_linux_arm64.zip"
-    sha256 "cb76403a31ecec5e945b56d91aed71f1fad0ee68102a4afead2f0c42274374d5"
-  end
-
-  conflicts_with "consul-enterprise"
-
-  def install
-    bin.install "consul"
-  end
-
-  service do
-    run [bin/"consul", "agent", "-dev", "-bind", "127.0.0.1"]
-    keep_alive successful_exit: false
-    working_dir var
-    log_path var/"log/consul.log"
-    error_log_path var/"log/consul.log"
-  end
-
-  test do
-    system "#{bin}/consul --version"
-  end
-end
-`
-
-	err := printFormula(product, version, config, buf)
-	require.Nil(t, err)
-	assert.Equal(t, expect, buf.String())
+	err = printFormula(product, version, config, buf)
+	require.NoError(t, err)
+	assert.Equal(t, string(expect), buf.String())
 }

--- a/util/formula_templater/testdata/consul-enterprise.rb
+++ b/util/formula_templater/testdata/consul-enterprise.rb
@@ -1,0 +1,48 @@
+class ConsulEnterprise < Formula
+  desc "Consul Enterprise"
+  homepage "https://www.consul.io"
+  version "1.15.1+ent"
+
+  if OS.mac? && Hardware::CPU.intel?
+    url "https://releases.hashicorp.com/consul/1.15.1+ent/consul_1.15.1+ent_darwin_amd64.zip"
+    sha256 "5a020a09b2dd7991f930596e751bdde51bba35b854912411e552782d4181618d"
+  end
+
+  if OS.mac? && Hardware::CPU.arm?
+    url "https://releases.hashicorp.com/consul/1.15.1+ent/consul_1.15.1+ent_darwin_arm64.zip"
+    sha256 "262bab1c8776f97cc74ae02bb347bcc223bfdc44f83dc9190ea098b451d3ee65"
+  end
+
+  if OS.linux? && Hardware::CPU.intel?
+    url "https://releases.hashicorp.com/consul/1.15.1+ent/consul_1.15.1+ent_linux_amd64.zip"
+    sha256 "5e5f8c4a55567c37187de35c802eef2f04e9184c5a7bad64a914256b14701422"
+  end
+
+  if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
+    url "https://releases.hashicorp.com/consul/1.15.1+ent/consul_1.15.1+ent_linux_arm.zip"
+    sha256 "7bc00fb0f373d9d71a8fa447602339033ad51bd2abbf1d084669adb2e6b76ac7"
+  end
+
+  if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+    url "https://releases.hashicorp.com/consul/1.15.1+ent/consul_1.15.1+ent_linux_arm64.zip"
+    sha256 "e2594c265b08b00a33dfeb65221876b63a25d34e5d4d8cb1c8e33d54d71ab503"
+  end
+
+  conflicts_with "consul-enterprise"
+
+  def install
+    bin.install "consul"
+  end
+
+  service do
+    run [bin/"consul", "agent", "-dev", "-bind", "127.0.0.1"]
+    keep_alive successful_exit: false
+    working_dir var
+    log_path var/"log/consul.log"
+    error_log_path var/"log/consul.log"
+  end
+
+  test do
+    system "#{bin}/consul --version"
+  end
+end

--- a/util/formula_templater/testdata/consul.rb
+++ b/util/formula_templater/testdata/consul.rb
@@ -1,0 +1,48 @@
+class Consul < Formula
+  desc "Consul"
+  homepage "https://www.consul.io"
+  version "1.15.1"
+
+  if OS.mac? && Hardware::CPU.intel?
+    url "https://releases.hashicorp.com/consul/1.15.1/consul_1.15.1_darwin_amd64.zip"
+    sha256 "311c593dc9be13475a42bd97016f302dbf174f6232c4fcf81218c21a5cb879ea"
+  end
+
+  if OS.mac? && Hardware::CPU.arm?
+    url "https://releases.hashicorp.com/consul/1.15.1/consul_1.15.1_darwin_arm64.zip"
+    sha256 "e06fd7783008a8944a4824747f3e8c9d98864960072201cad615f26d42ce99e0"
+  end
+
+  if OS.linux? && Hardware::CPU.intel?
+    url "https://releases.hashicorp.com/consul/1.15.1/consul_1.15.1_linux_amd64.zip"
+    sha256 "23f7eb0461dd01a95c5d56472b91c22d5dacec84f31f1846c0c9f9621f98f29f"
+  end
+
+  if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
+    url "https://releases.hashicorp.com/consul/1.15.1/consul_1.15.1_linux_arm.zip"
+    sha256 "09c53fc66d46b132d5f7acb7d21758056602be9495c8a1d409ec8cef45328dd8"
+  end
+
+  if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+    url "https://releases.hashicorp.com/consul/1.15.1/consul_1.15.1_linux_arm64.zip"
+    sha256 "4e5e42186ff9f7a3e9736f871a81ff3732f7e150664376e1bf290661544a4654"
+  end
+
+  conflicts_with "consul"
+
+  def install
+    bin.install "consul"
+  end
+
+  service do
+    run [bin/"consul", "agent", "-dev", "-bind", "127.0.0.1"]
+    keep_alive successful_exit: false
+    working_dir var
+    log_path var/"log/consul.log"
+    error_log_path var/"log/consul.log"
+  end
+
+  test do
+    system "#{bin}/consul --version"
+  end
+end


### PR DESCRIPTION
Also, update the testdata due to the resigning that happened in #218. This process changed the 1.13.2 checksums, for reproducibility I updated the testdata to the current versions that can be pulled from git.