### PR TITLE
Prevent publishing a formula with missing digests

### DIFF
--- a/util/formula_templater/formula.go
+++ b/util/formula_templater/formula.go
@@ -40,27 +40,42 @@ func printFormula(product, version, configLocation string, out io.Writer) error 
 		t = template.Must(template.New("cask").Parse(caskTemplate))
 	} else {
 		if productConfig.Architectures.DarwinAmd64 {
-			sha := getShasum(shasums, product, version, "darwin_amd64")
+			sha, err := getShasum(shasums, product, version, "darwin_amd64")
+			if err != nil {
+				return fmt.Errorf("no SHA found for darwin_amd64: %w", err)
+			}
 			productConfig.Architectures.DarwinAmd64SHA = sha
 		}
 
 		if productConfig.Architectures.DarwinArm64 {
-			sha := getShasum(shasums, product, version, "darwin_arm64")
+			sha, err := getShasum(shasums, product, version, "darwin_arm64")
+			if err != nil {
+				return fmt.Errorf("no SHA found for darwin_arm64: %w", err)
+			}
 			productConfig.Architectures.DarwinArm64SHA = sha
 		}
 
 		if productConfig.Architectures.LinuxAmd64 {
-			sha := getShasum(shasums, product, version, "linux_amd64")
+			sha, err := getShasum(shasums, product, version, "linux_amd64")
+			if err != nil {
+				return fmt.Errorf("no SHA found for linux_amdd64: %w", err)
+			}
 			productConfig.Architectures.LinuxAmd64SHA = sha
 		}
 
 		if productConfig.Architectures.LinuxArm {
-			sha := getShasum(shasums, product, version, "linux_arm")
+			sha, err := getShasum(shasums, product, version, "linux_arm")
+			if err != nil {
+				return fmt.Errorf("no SHA found for linux_arm: %w", err)
+			}
 			productConfig.Architectures.LinuxArmSHA = sha
 		}
 
 		if productConfig.Architectures.LinuxArm64 {
-			sha := getShasum(shasums, product, version, "linux_arm64")
+			sha, err := getShasum(shasums, product, version, "linux_arm64")
+			if err != nil {
+				return fmt.Errorf("no SHA found for linux_arm64: %w", err)
+			}
 			productConfig.Architectures.LinuxArm64SHA = sha
 		}
 

--- a/util/formula_templater/formula_test.go
+++ b/util/formula_templater/formula_test.go
@@ -36,3 +36,17 @@ func TestPrintENTFormula(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, string(expect), buf.String())
 }
+
+func TestVariantHandling(t *testing.T) {
+	product := "vault-enterprise"
+	version := "1.13.0+ent.hsm.fips1402"
+	config := "./config.hcl"
+	buf := new(bytes.Buffer)
+
+	err := printFormula(product, version, config, buf)
+	assert.Error(t, err)
+	// Check the error, mostly to check the error contains actionable information.
+	// It currently relies on ordering (darwin_amd64 is tested first), so if that changes test case should be updated
+	// as needed.
+	assert.ErrorContains(t, err, "no SHA found for darwin_amd64: no value found for `vault_1.13.0+ent.hsm.fips1402_darwin_amd64.zip`")
+}

--- a/util/formula_templater/shasums.go
+++ b/util/formula_templater/shasums.go
@@ -48,8 +48,12 @@ func loadShasums(product, version string) (map[string]string, error) {
 	return shasums, nil
 }
 
-func getShasum(shasums map[string]string, product, version, arch string) string {
+func getShasum(shasums map[string]string, product, version, arch string) (string, error) {
 	product = returnProduct(product)
 	zip := fmt.Sprintf("%s_%s_%s.zip", product, version, arch)
-	return shasums[zip]
+	digest, ok := shasums[zip]
+	if !ok {
+		return digest, fmt.Errorf("no value found for `%s`", zip)
+	}
+	return digest, nil
 }


### PR DESCRIPTION
Recently the vault-enterprise HSM variant was published and this incorrectly updated the brew formula to use it. It also silently removed the digests from the files (set them to empty strings). This change forces the digests to be set.