### PR TITLE
manual fix for vagrant 2.3.5

### DIFF
--- a/Casks/hashicorp-vagrant.rb
+++ b/Casks/hashicorp-vagrant.rb
@@ -1,6 +1,6 @@
 cask "hashicorp-vagrant" do
-  version "2.3.4"
-  sha256 "0015f971c20cce4cd3c97ed758f1e0b528bffe0dc02f0ab55da4b216cb5748b8"
+  version "2.3.5"
+  sha256 "86e49a1db16599a8dc84f76b18fed89787f844917c55b6d589e14d025f8134b1"
 
   url "https://releases.hashicorp.com/vagrant/#{version}/vagrant_#{version}_darwin_amd64.dmg", 
       verified: "hashicorp.com/vagrant/"


### PR DESCRIPTION
This failed to update after the latest vagrant release - possibly due to the gh tag not being updated. This quick manual fix gets them up and running while I look into the failure.