### PR TITLE
change vagrant livecheck to gh_latest

### DIFF
--- a/Casks/hashicorp-vagrant.rb
+++ b/Casks/hashicorp-vagrant.rb
@@ -10,7 +10,7 @@ cask "hashicorp-vagrant" do
 
   livecheck do
     url "https://github.com/hashicorp/vagrant"
-    strategy :git
+    strategy :github_latest
   end
 
   pkg "vagrant.pkg"


### PR DESCRIPTION
This adds a strategy that was recently added to homebrew's copy of this cask in order to prevent prerelease versions from being picked up.