### PR TITLE
pin and update action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab #v3.5.2
       -
         name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 #v4.0.1
         with:
           cache: true
           cache-dependency-path: util/formula_templater/go.sum
@@ -43,10 +43,10 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab #v3.5.2
       -
         name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 #v4.0.1
         with:
           cache: true
           cache-dependency-path: util/lambda_trigger/go.sum

--- a/.github/workflows/publish-formula-update.yml
+++ b/.github/workflows/publish-formula-update.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab #v3.5.2
 
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 #v4.0.1
         with:
           go-version-file: "util/formula_templater/go.mod"
 


### PR DESCRIPTION
I noticed node deprecation errors when troubleshooting an unrelated issue - this attends to those and also meets security's req for pinning actions.