### PR TITLE
add heimdall files and fix codeowners scope

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in
 # the repo, unless a later match takes precedence. 
 
-@hashicorp/release-engineering
+* @hashicorp/release-engineering

--- a/META.d/_summary.yaml
+++ b/META.d/_summary.yaml
@@ -1,0 +1,8 @@
+---
+schema: 1.1
+category: tooling
+summary:
+  owner: team-rel-eng
+  description: |
+    Homebrew casks and taps for HashiCorp products.
+  visibility: external

--- a/META.d/data.yml
+++ b/META.d/data.yml
@@ -1,0 +1,3 @@
+_summary:
+  gdpr:
+    exempt: true

--- a/META.d/tags.yaml
+++ b/META.d/tags.yaml
@@ -1,0 +1,4 @@
+---
+# excemption required by automation
+tags:
+  exempt: github-default-branch-protection-rule


### PR DESCRIPTION
Per RELENG-639, adds heimdall compliance and fixes scope of codeowners.