### PR TITLE
Remove duplicate cask

### DIFF
--- a/.github/workflows/manual-publish-formula-update.yml
+++ b/.github/workflows/manual-publish-formula-update.yml
@@ -1,5 +1,6 @@
 name: Manual update Product Formula in Tap
 # In the case of automation failure, this workflow allows a user to manually run a product version update.
+# Note for casks - the templater automatically adds "hashicorp-" as a prefix, so only use product name.
 on:
     workflow_dispatch:
       inputs:

--- a/Casks/hashicorp-hashicorp-vagrant.rb
+++ b/Casks/hashicorp-hashicorp-vagrant.rb
@@ -1,1 +1,0 @@
-Formula not found


### PR DESCRIPTION
I duplicated  a cask when manually triggering a fix last week because I was unaware that the templater automatically prepended the product name with "hashicorp-". This removes that duplicate and adds a note for future maintainers.