### PR TITLE
Ignore variant releases overridding core versions

### DIFF
--- a/util/lambda_trigger/Makefile
+++ b/util/lambda_trigger/Makefile
@@ -30,3 +30,4 @@ testdata:
 	curl --fail --silent 'https://raw.githubusercontent.com/hashicorp/homebrew-tap/a1a4af71310cc99c00259cda7c39a981b66442d4/Formula/nomad.rb' --output testdata/github.com_formula_nomad.rb
 	curl --fail --silent 'https://raw.githubusercontent.com/hashicorp/homebrew-tap/a1a4af71310cc99c00259cda7c39a981b66442d4/Formula/nomad-enterprise.rb' --output testdata/github.com_formula_nomad-enterprise.rb
 	curl --fail --silent 'https://raw.githubusercontent.com/hashicorp/homebrew-tap/525cf0610587cef5cb6a40f31c8d92f70f335fb4/Casks/hashicorp-boundary-desktop.rb' --output testdata/github.com_cask_boundary-desktop.rb
+	curl --fail --silent 'https://api.releases.hashicorp.com/v1/releases/vault/1.13.3+ent.hsm.fips1402?license_class=enterprise' | jq --sort-keys > testdata/releases.com_vault-enterprise_latest.json

--- a/util/lambda_trigger/lambda_trigger_test.go
+++ b/util/lambda_trigger/lambda_trigger_test.go
@@ -257,3 +257,17 @@ func TestHandleLambdaEventNewProduct(t *testing.T) {
 	})
 	assert.NoError(t, err)
 }
+
+func TestGetLatestVersionIgnoresVariants(t *testing.T) {
+	defer gock.Off()
+	gock.New("https://api.releases.hashicorp.com").
+		Get("/v1/releases/vault/latest").
+		MatchParam("license_class", "enterprise").
+		Reply(200).
+		File("testdata/releases.com_vault-enterprise_latest.json")
+
+	gotLatest, err := getLatestVersion("vault-enterprise")
+
+	require.NoError(t, err)
+	assert.Equal(t, "1.13.3+ent", *gotLatest)
+}

--- a/util/lambda_trigger/testdata/releases.com_vault-enterprise_latest.json
+++ b/util/lambda_trigger/testdata/releases.com_vault-enterprise_latest.json
@@ -1,0 +1,30 @@
+{
+  "builds": [
+    {
+      "arch": "amd64",
+      "os": "linux",
+      "url": "https://releases.hashicorp.com/vault/1.13.3+ent.hsm.fips1402/vault_1.13.3+ent.hsm.fips1402_linux_amd64.zip"
+    }
+  ],
+  "is_prerelease": false,
+  "license_class": "enterprise",
+  "name": "vault",
+  "status": {
+    "state": "supported",
+    "timestamp_updated": "2023-06-08T01:50:27.689Z"
+  },
+  "timestamp_created": "2023-06-08T01:50:27.689Z",
+  "timestamp_updated": "2023-06-08T01:50:27.689Z",
+  "url_changelog": "https://github.com/hashicorp/vault-enterprise/blob/release/1.13.x+ent/CHANGELOG.md",
+  "url_docker_registry_dockerhub": "https://hub.docker.com/r/hashicorp/vault-enterprise",
+  "url_docker_registry_ecr": "https://gallery.ecr.aws/hashicorp/vault-enterprise",
+  "url_license": "https://github.com/hashicorp/vault/blob/main/LICENSE",
+  "url_project_website": "https://www.vaultproject.io/docs/enterprise",
+  "url_release_notes": "https://www.vaultproject.io/docs/release-notes",
+  "url_shasums": "https://releases.hashicorp.com/vault/1.13.3+ent.hsm.fips1402/vault_1.13.3+ent.hsm.fips1402_SHA256SUMS",
+  "url_shasums_signatures": [
+    "https://releases.hashicorp.com/vault/1.13.3+ent.hsm.fips1402/vault_1.13.3+ent.hsm.fips1402_SHA256SUMS.sig",
+    "https://releases.hashicorp.com/vault/1.13.3+ent.hsm.fips1402/vault_1.13.3+ent.hsm.fips1402_SHA256SUMS.72D7468F.sig"
+  ],
+  "version": "1.13.3+ent.hsm.fips1402"
+}


### PR DESCRIPTION
This addresses the root cause behind mistakenly publishing vault's fips variants as the main version in #223, #206, and most recently, 64171e0a.

The Releases API does not allow us to filter by variant, so we hardcode the variant we are interested in. This restricts publishing to just our base variants of enterprise and OSS. Perhaps in the future we can revisit this to support homebrew publishing of our variants.

Related HREL-1