### PR TITLE
Cask support enhancements

### DIFF
--- a/.github/workflows/manual-publish-formula-update.yml
+++ b/.github/workflows/manual-publish-formula-update.yml
@@ -43,6 +43,7 @@ jobs:
         if: ${{ github.event.inputs.is_cask == 'true' }}
         run: |
           ./util/formula_templater/formula_templater \
+            -cask \
             ${{github.event.inputs.product}} \
             ${{github.event.inputs.version}} \
             ./util/formula_templater/config.hcl > ./Casks/hashicorp-${{github.event.inputs.product}}.rb

--- a/.github/workflows/publish-formula-update.yml
+++ b/.github/workflows/publish-formula-update.yml
@@ -36,6 +36,7 @@ jobs:
         if: ${{ github.event.client_payload.cask == 'true' }}
         run: |
           ./util/formula_templater/formula_templater \
+            -cask \
             ${{github.event.client_payload.name}} \
             ${{github.event.client_payload.version}} \
             ./util/formula_templater/config.hcl > ./Casks/hashicorp-${{github.event.client_payload.name}}.rb

--- a/util/formula_templater/config.go
+++ b/util/formula_templater/config.go
@@ -9,6 +9,7 @@ import (
 // Config configuration top level options
 type Config struct {
 	Formulae []FormulaConfig `hcl:"formula,block"`
+	Casks    []CaskConfig    `hcl:"cask,block"`
 }
 
 // FormulaConfig all required formula data
@@ -19,17 +20,28 @@ type FormulaConfig struct {
 	Desc          string `hcl:"desc"`
 	Homepage      string `hcl:"homepage"`
 	Version       string
-	Architectures FormulaArchitectures `hcl:"architectures,block"`
-	Depends       []string             `hcl:"depends,optional"`
-	Recommends    []string             `hcl:"recommends,optional"`
-	ServiceArgs   []string             `hcl:"service_args,optional"`
-	Cask          bool                 `hcl:"cask,optional"`
-	CaskApp       string               `hcl:"cask_app,optional"`
-	CaskPkg       string               `hcl:"cask_pkg,optional"`
+	Architectures Architectures `hcl:"architectures,block"`
+
+	Depends     []string `hcl:"depends,optional"`
+	Recommends  []string `hcl:"recommends,optional"`
+	ServiceArgs []string `hcl:"service_args,optional"`
 }
 
-// FormulaArchitectures architecture support
-type FormulaArchitectures struct {
+type CaskConfig struct {
+	Product       string `hcl:"product"`
+	Variant       string `hcl:"variant,optional"`
+	Name          string `hcl:"name"`
+	Desc          string `hcl:"desc"`
+	Homepage      string `hcl:"homepage"`
+	Version       string
+	Architectures Architectures `hcl:"architectures,block"`
+
+	CaskApp string `hcl:"cask_app,optional"`
+	CaskPkg string `hcl:"cask_pkg,optional"`
+}
+
+// Architectures architecture support
+type Architectures struct {
 	DarwinAmd64    bool `hcl:"darwin_amd64"`
 	DarwinAmd64SHA string
 	DarwinArm64    bool `hcl:"darwin_arm64"`
@@ -58,4 +70,14 @@ func (c Config) getFormula(product string) (FormulaConfig, error) {
 	}
 
 	return FormulaConfig{}, errors.New("Formula not found")
+}
+
+func (c Config) getCask(product string) (CaskConfig, error) {
+	for _, cask := range c.Casks {
+		if cask.Product == product {
+			return cask, nil
+		}
+	}
+
+	return CaskConfig{}, errors.New("Cask not found")
 }

--- a/util/formula_templater/config.hcl
+++ b/util/formula_templater/config.hcl
@@ -314,12 +314,11 @@ formula {
     }
 }
 
-formula {
+cask {
     product = "boundary-desktop"
     name = "Boundary Desktop"
     desc = ""
     homepage = "https://www.boundaryproject.io/"
-    cask = true
     cask_app = "Boundary.app"
     architectures {
         darwin_amd64 = true
@@ -377,11 +376,24 @@ formula {
     name = "Vagrant"
     desc = "Development environment"
     homepage = "https://www.vagrantup.com/"
-    cask = true
+    architectures {
+        darwin_amd64 = false
+        darwin_arm64 = false
+        linux_amd64 = true
+        linux_arm = false
+        linux_arm64 = false
+    }
+}
+
+cask {
+    product = "vagrant"
+    name = "Vagrant"
+    desc = "Development environment"
+    homepage = "https://www.vagrantup.com/"
     cask_pkg = "vagrant.pkg"
     architectures {
         darwin_amd64 = true
-        darwin_arm64 = false
+        darwin_arm64 = true
         linux_amd64 = false
         linux_arm = false
         linux_arm64 = false

--- a/util/formula_templater/formula.go
+++ b/util/formula_templater/formula.go
@@ -14,6 +14,38 @@ var formulaTemplate string
 //go:embed templates/cask.tmpl
 var caskTemplate string
 
+func printCask(product, version, configLocation string, out io.Writer) error {
+	shasums, err := loadShasums(product, version)
+	if err != nil {
+		return err
+	}
+
+	config, err := loadConfig(configLocation)
+	if err != nil {
+		return err
+	}
+
+	productConfig, err := config.getCask(product)
+	if err != nil {
+		return err
+	}
+	productConfig.Version = version
+
+	if productConfig.Architectures.DarwinAmd64 {
+		dmg := fmt.Sprintf("%s_%s_%s.dmg", product, version, "darwin_amd64")
+		productConfig.Architectures.DarwinAmd64SHA = shasums[dmg]
+	}
+
+	if productConfig.Architectures.DarwinArm64 {
+		dmg := fmt.Sprintf("%s_%s_%s.dmg", product, version, "darwin_arm64")
+		productConfig.Architectures.DarwinArm64SHA = shasums[dmg]
+	}
+
+	t := template.Must(template.New("cask").Parse(caskTemplate))
+
+	return t.Execute(out, productConfig)
+}
+
 func printFormula(product, version, configLocation string, out io.Writer) error {
 	shasums, err := loadShasums(product, version)
 	if err != nil {
@@ -31,65 +63,56 @@ func printFormula(product, version, configLocation string, out io.Writer) error 
 	}
 
 	productConfig.Version = version
-
-	var t *template.Template
-	if productConfig.Cask {
-		dmg := fmt.Sprintf("%s_%s_%s.dmg", product, version, "darwin_amd64")
-		productConfig.Architectures.DarwinAmd64SHA = shasums[dmg]
-
-		t = template.Must(template.New("cask").Parse(caskTemplate))
-	} else {
-		if productConfig.Architectures.DarwinAmd64 {
-			sha, err := getShasum(shasums, product, version, "darwin_amd64")
-			if err != nil {
-				return fmt.Errorf("no SHA found for darwin_amd64: %w", err)
-			}
-			productConfig.Architectures.DarwinAmd64SHA = sha
+	if productConfig.Architectures.DarwinAmd64 {
+		sha, err := getShasum(shasums, product, version, "darwin_amd64")
+		if err != nil {
+			return fmt.Errorf("no SHA found for darwin_amd64: %w", err)
 		}
-
-		if productConfig.Architectures.DarwinArm64 {
-			sha, err := getShasum(shasums, product, version, "darwin_arm64")
-			if err != nil {
-				return fmt.Errorf("no SHA found for darwin_arm64: %w", err)
-			}
-			productConfig.Architectures.DarwinArm64SHA = sha
-		}
-
-		if productConfig.Architectures.LinuxAmd64 {
-			sha, err := getShasum(shasums, product, version, "linux_amd64")
-			if err != nil {
-				return fmt.Errorf("no SHA found for linux_amdd64: %w", err)
-			}
-			productConfig.Architectures.LinuxAmd64SHA = sha
-		}
-
-		if productConfig.Architectures.LinuxArm {
-			sha, err := getShasum(shasums, product, version, "linux_arm")
-			if err != nil {
-				return fmt.Errorf("no SHA found for linux_arm: %w", err)
-			}
-			productConfig.Architectures.LinuxArmSHA = sha
-		}
-
-		if productConfig.Architectures.LinuxArm64 {
-			sha, err := getShasum(shasums, product, version, "linux_arm64")
-			if err != nil {
-				return fmt.Errorf("no SHA found for linux_arm64: %w", err)
-			}
-			productConfig.Architectures.LinuxArm64SHA = sha
-		}
-
-		// For enterprise products only, set a Variant variable to 'enterprise'
-		// and update the product name to be the base product without the variant
-		// e.g. product name will be 'vault' instead of 'vault-enterprise
-		// This is needed to produce the right Formula.rb files for ENT products
-		if strings.HasSuffix(strings.ToLower(productConfig.Product), "-enterprise") {
-			productConfig.Variant = "enterprise"
-			productConfig.Product = strings.TrimSuffix(productConfig.Product, "-enterprise")
-		}
-
-		t = template.Must(template.New("formula").Parse(formulaTemplate))
+		productConfig.Architectures.DarwinAmd64SHA = sha
 	}
+
+	if productConfig.Architectures.DarwinArm64 {
+		sha, err := getShasum(shasums, product, version, "darwin_arm64")
+		if err != nil {
+			return fmt.Errorf("no SHA found for darwin_arm64: %w", err)
+		}
+		productConfig.Architectures.DarwinArm64SHA = sha
+	}
+
+	if productConfig.Architectures.LinuxAmd64 {
+		sha, err := getShasum(shasums, product, version, "linux_amd64")
+		if err != nil {
+			return fmt.Errorf("no SHA found for linux_amdd64: %w", err)
+		}
+		productConfig.Architectures.LinuxAmd64SHA = sha
+	}
+
+	if productConfig.Architectures.LinuxArm {
+		sha, err := getShasum(shasums, product, version, "linux_arm")
+		if err != nil {
+			return fmt.Errorf("no SHA found for linux_arm: %w", err)
+		}
+		productConfig.Architectures.LinuxArmSHA = sha
+	}
+
+	if productConfig.Architectures.LinuxArm64 {
+		sha, err := getShasum(shasums, product, version, "linux_arm64")
+		if err != nil {
+			return fmt.Errorf("no SHA found for linux_arm64: %w", err)
+		}
+		productConfig.Architectures.LinuxArm64SHA = sha
+	}
+
+	// For enterprise products only, set a Variant variable to 'enterprise'
+	// and update the product name to be the base product without the variant
+	// e.g. product name will be 'vault' instead of 'vault-enterprise
+	// This is needed to produce the right Formula.rb files for ENT products
+	if strings.HasSuffix(strings.ToLower(productConfig.Product), "-enterprise") {
+		productConfig.Variant = "enterprise"
+		productConfig.Product = strings.TrimSuffix(productConfig.Product, "-enterprise")
+	}
+
+	t := template.Must(template.New("formula").Parse(formulaTemplate))
 
 	return t.Execute(out, productConfig)
 }

--- a/util/formula_templater/formula_test.go
+++ b/util/formula_templater/formula_test.go
@@ -23,6 +23,48 @@ func TestPrintOSSFormula(t *testing.T) {
 	assert.Equal(t, string(expect), buf.String())
 }
 
+func TestPrintOSSCask(t *testing.T) {
+	expect, err := os.ReadFile("testdata/boundary-desktop-cask.rb")
+	require.NoError(t, err)
+
+	product := "boundary-desktop"
+	version := "1.6.0"
+	config := "./config.hcl"
+	buf := new(bytes.Buffer)
+
+	err = printCask(product, version, config, buf)
+	require.NoError(t, err)
+	assert.Equal(t, string(expect), buf.String())
+}
+
+func TestPrintOSSCaskMultiArch(t *testing.T) {
+	expect, err := os.ReadFile("testdata/vagrant-cask.rb")
+	require.NoError(t, err)
+
+	product := "vagrant"
+	version := "2.3.6"
+	config := "./config.hcl"
+	buf := new(bytes.Buffer)
+
+	err = printCask(product, version, config, buf)
+	require.NoError(t, err)
+	assert.Equal(t, string(expect), buf.String())
+}
+
+func TestPrintOSSFormulaNoMac(t *testing.T) {
+	expect, err := os.ReadFile("testdata/vagrant-formula.rb")
+	require.NoError(t, err)
+
+	product := "vagrant"
+	version := "2.3.6"
+	config := "./config.hcl"
+	buf := new(bytes.Buffer)
+
+	err = printFormula(product, version, config, buf)
+	require.NoError(t, err)
+	assert.Equal(t, string(expect), buf.String())
+}
+
 func TestPrintENTFormula(t *testing.T) {
 	expect, err := os.ReadFile("testdata/consul-enterprise.rb")
 	require.NoError(t, err)

--- a/util/formula_templater/main.go
+++ b/util/formula_templater/main.go
@@ -8,13 +8,33 @@ import (
 // Usage: formula_templater <product> <version> <configPath>
 // Example: formula_templater vault 1.6.3 ./config.hcl
 func main() {
-	product := os.Args[1]
-	version := os.Args[2]
-	config := os.Args[3]
+	if len(os.Args) < 4 || len(os.Args) > 5 {
+		fmt.Printf("Usage: %s [-cask] PRODUCT VERSION CONFIG_PATH", os.Args[0])
+		os.Exit(1)
+	}
 
-	err := printFormula(product, version, config, os.Stdout)
-	if err != nil {
+	i := 0
+	cask := false
+	if os.Args[1] == "-cask" {
+		cask = true
+		i += 1
+	}
+
+	product := os.Args[i+1]
+	version := os.Args[i+2]
+	config := os.Args[i+3]
+
+	if cask {
+		if err := printCask(product, version, config, os.Stdout); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
+	if err := printFormula(product, version, config, os.Stdout); err != nil {
 		fmt.Println(err)
+		os.Exit(1)
 	}
 	os.Exit(0)
 }

--- a/util/formula_templater/templates/cask.tmpl
+++ b/util/formula_templater/templates/cask.tmpl
@@ -3,10 +3,26 @@
 
 cask "hashicorp-{{ .Product }}" do
   version "{{ .Version }}"
+  {{- if and .Architectures.DarwinAmd64SHA .Architectures.DarwinArm64SHA }}
+  arch arm: "arm64", intel: "amd64"
+  sha256 arm: "{{ .Architectures.DarwinArm64SHA }}",
+         intel: "{{ .Architectures.DarwinAmd64SHA }}"
+  url "https://releases.hashicorp.com/{{ .Product }}/#{version}/{{ .Product }}_#{version}_darwin_#{arch}.dmg",
+      verified: "hashicorp.com/{{ .Product }}/"
+  {{- else }}
+  {{- if .Architectures.DarwinAmd64SHA }}
   sha256 "{{ .Architectures.DarwinAmd64SHA }}"
 
   url "https://releases.hashicorp.com/{{ .Product }}/#{version}/{{ .Product }}_#{version}_darwin_amd64.dmg",
       verified: "hashicorp.com/{{ .Product }}/"
+  {{- end }}
+  {{- if .Architectures.DarwinArm64SHA }}
+  sha256 "{{ .Architectures.DarwinArm64SHA }}"
+
+  url "https://releases.hashicorp.com/{{ .Product }}/#{version}/{{ .Product }}_#{version}_darwin_arm64.dmg",
+      verified: "hashicorp.com/{{ .Product }}/"
+  {{- end }}
+  {{- end }}
   name "{{ .Name }}"
   desc "{{ .Desc }}"
   homepage "{{ .Homepage }}"

--- a/util/formula_templater/templates/formula.tmpl
+++ b/util/formula_templater/templates/formula.tmpl
@@ -6,6 +6,7 @@ class {{ .Name }} < Formula
   homepage "{{ .Homepage }}"
   version "{{ .Version }}"
 
+  {{- if or .Architectures.DarwinAmd64 .Architectures.DarwinArm64 }}
   {{- if and .Architectures.DarwinAmd64 .Architectures.DarwinArm64 }}
 
   if OS.mac? && Hardware::CPU.intel?
@@ -34,6 +35,7 @@ class {{ .Name }} < Formula
       EOS
     end
   end
+  {{- end }}
   {{- end }}
   {{- if .Architectures.LinuxAmd64 }}
 

--- a/util/formula_templater/testdata/boundary-desktop-cask.rb
+++ b/util/formula_templater/testdata/boundary-desktop-cask.rb
@@ -1,0 +1,16 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+cask "hashicorp-boundary-desktop" do
+  version "1.6.0"
+  sha256 "b6b5b15dfb469b7fdab9216788f5931e96561104de1ff7f9e0d6fda54701be09"
+
+  url "https://releases.hashicorp.com/boundary-desktop/#{version}/boundary-desktop_#{version}_darwin_amd64.dmg",
+      verified: "hashicorp.com/boundary-desktop/"
+  name "Boundary Desktop"
+  desc ""
+  homepage "https://www.boundaryproject.io/"
+
+  app "Boundary.app"
+
+end

--- a/util/formula_templater/testdata/vagrant-cask.rb
+++ b/util/formula_templater/testdata/vagrant-cask.rb
@@ -1,0 +1,31 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+cask "hashicorp-vagrant" do
+  version "2.3.6"
+  arch arm: "arm64", intel: "amd64"
+  sha256 arm: "4daf4d4c323cce7bf98065ecf5338e9800038a522cd81356c77555d9cd2f0db9",
+         intel: "4daf4d4c323cce7bf98065ecf5338e9800038a522cd81356c77555d9cd2f0db9"
+  url "https://releases.hashicorp.com/vagrant/#{version}/vagrant_#{version}_darwin_#{arch}.dmg",
+      verified: "hashicorp.com/vagrant/"
+  name "Vagrant"
+  desc "Development environment"
+  homepage "https://www.vagrantup.com/"
+
+  livecheck do
+    url "https://github.com/hashicorp/vagrant"
+    strategy :git
+  end
+
+  pkg "vagrant.pkg"
+
+  uninstall script: {
+    executable: "uninstall.tool",
+    input: ["Yes"],
+    sudo:  true,
+  },
+  pkgutil: "com.vagrant.vagrant"
+
+  zap trash: "~/.vagrant.d"
+
+end

--- a/util/formula_templater/testdata/vagrant-formula.rb
+++ b/util/formula_templater/testdata/vagrant-formula.rb
@@ -1,0 +1,23 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+class Vagrant < Formula
+  desc "Development environment"
+  homepage "https://www.vagrantup.com/"
+  version "2.3.6"
+
+  if OS.linux? && Hardware::CPU.intel?
+    url "https://releases.hashicorp.com/vagrant/2.3.6/vagrant_2.3.6_linux_amd64.zip"
+    sha256 "71a616220e0f68d4882573afed4263a362eaafd14833a4f7e7c26f0cc0490157"
+  end
+
+  conflicts_with "vagrant"
+
+  def install
+    bin.install "vagrant"
+  end
+
+  test do
+    system "#{bin}/vagrant --version"
+  end
+end

--- a/util/lambda_trigger/lambda_trigger_test.go
+++ b/util/lambda_trigger/lambda_trigger_test.go
@@ -1,6 +1,12 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/url"
+	"os"
 	"testing"
 	"time"
 
@@ -270,4 +276,306 @@ func TestGetLatestVersionIgnoresVariants(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "1.13.3+ent", *gotLatest)
+}
+
+func Test_isProductSupported(t *testing.T) {
+	require := require.New(t)
+	t.Run("when product is supported", func(t *testing.T) {
+		require.True(isProductSupported("vault"))
+	})
+
+	t.Run("when product is not supported", func(t *testing.T) {
+		require.False(isProductSupported("unknown-product"))
+	})
+}
+
+func Test_isFormula(t *testing.T) {
+	require := require.New(t)
+	t.Run("when product is formula only", func(t *testing.T) {
+		require.True(isFormula("vault"))
+	})
+
+	t.Run("when product is formula and cask", func(t *testing.T) {
+		require.True(isFormula("vagrant"))
+	})
+
+	t.Run("when product is cask only", func(t *testing.T) {
+		require.False(isFormula("boundary-desktop"))
+	})
+}
+
+func Test_isCask(t *testing.T) {
+	require := require.New(t)
+	t.Run("when product is formula only", func(t *testing.T) {
+		require.False(isCask("vault"))
+	})
+
+	t.Run("when product is formula and cask", func(t *testing.T) {
+		require.True(isCask("vagrant"))
+	})
+
+	t.Run("when product is cask only", func(t *testing.T) {
+		require.True(isCask("boundary-desktop"))
+	})
+}
+
+func TestHandleLambdaEvent(t *testing.T) {
+	require := require.New(t)
+	successfulTest := "test was succesful"
+
+	t.Run("when product is formula only", func(t *testing.T) {
+		t.Run("when versions are different", func(t *testing.T) {
+			reader, writer, cleanup := enableStdoutCapture(t)
+			defer cleanup()
+			defer gock.Off()
+			// Mock all the expected http requests
+			generateFormulaMock("nomad").Reply(200).
+				BodyString(generateFormulaReply("nomad", "1.3.5"))
+			generateReleasesLatestMock("nomad").Reply(200).
+				BodyString(generateReleasesReply("nomad", "1.3.6"))
+			generateDispatchMock().
+				MatchType("json").
+				BodyString(`.*"cask":"false".*`). // ensure cask job is not triggered
+				Reply(200).
+				BodyString(successfulTest)
+
+			require.NoError(HandleLambdaEvent(generateSnsEvent("nomad", "1.3.6")))
+			writer.Close()
+			result, err := ioutil.ReadAll(reader)
+			require.NoError(err)
+			require.Contains(string(result), successfulTest)
+		})
+
+		t.Run("when versions are the same", func(t *testing.T) {
+			defer gock.Off()
+			generateFormulaMock("nomad").Reply(200).
+				BodyString(generateFormulaReply("nomad", "1.3.5"))
+			generateReleasesLatestMock("nomad").Reply(200).
+				BodyString(generateReleasesReply("nomad", "1.3.5"))
+
+			err := HandleLambdaEvent(generateSnsEvent("nomad", "1.3.5"))
+			require.Error(err)
+			require.Contains(err.Error(), "latest version")
+		})
+	})
+
+	t.Run("when product is cask only", func(t *testing.T) {
+		t.Run("when versions are different", func(t *testing.T) {
+			reader, writer, cleanup := enableStdoutCapture(t)
+			defer cleanup()
+			defer gock.Off()
+			generateCaskMock("boundary-desktop").Reply(200).
+				BodyString(generateCaskReply("boundary-desktop", "1.1.1"))
+			generateReleasesLatestMock("boundary-desktop").Reply(200).
+				BodyString(generateReleasesReply("boundary-desktop", "1.1.2"))
+			generateDispatchMock().
+				MatchType("json").
+				BodyString(`.*"cask":"true".*`). // ensure cask job is triggered
+				Reply(200).
+				BodyString(successfulTest)
+
+			require.NoError(HandleLambdaEvent(generateSnsEvent("boundary-desktop", "1.1.2")))
+			writer.Close()
+			result, err := ioutil.ReadAll(reader)
+			require.NoError(err)
+			require.Contains(string(result), successfulTest)
+		})
+
+		t.Run("when versions are the same", func(t *testing.T) {
+			defer gock.Off()
+			generateCaskMock("boundary-desktop").Reply(200).
+				BodyString(generateCaskReply("boundary-desktop", "1.1.1"))
+			generateReleasesLatestMock("boundary-desktop").Reply(200).
+				BodyString(generateReleasesReply("boundary-desktop", "1.1.1"))
+
+			err := HandleLambdaEvent(generateSnsEvent("boundary-desktop", "1.1.2"))
+			require.Error(err)
+			require.Contains(err.Error(), "latest version")
+		})
+	})
+
+	t.Run("when product is formula and cask", func(t *testing.T) {
+		formulaSuccess := "formula test success"
+		caskSuccess := "cask test success"
+		t.Run("when versions are different", func(t *testing.T) {
+			t.Run("it should trigger workflow twice", func(t *testing.T) {
+				reader, writer, cleanup := enableStdoutCapture(t)
+				defer cleanup()
+				defer gock.Off()
+				generateCaskMock("vagrant").Reply(200).
+					BodyString(generateCaskReply("vagrant", "1.0.1"))
+				generateReleasesLatestMock("vagrant").Reply(200).
+					BodyString(generateReleasesReply("vagrant", "1.0.2"))
+				generateDispatchMock().Reply(200).
+					BodyString(caskSuccess)
+				generateDispatchMock().Reply(200).
+					BodyString(formulaSuccess)
+
+				require.NoError(HandleLambdaEvent(generateSnsEvent("vagrant", "1.0.2")))
+				writer.Close()
+				result, err := ioutil.ReadAll(reader)
+				require.NoError(err)
+				require.Contains(string(result), caskSuccess)
+				require.Contains(string(result), formulaSuccess)
+			})
+
+			t.Run("it should trigger cask workflow", func(t *testing.T) {
+				reader, writer, cleanup := enableStdoutCapture(t)
+				defer cleanup()
+				defer gock.Off()
+				generateCaskMock("vagrant").Reply(200).
+					BodyString(generateCaskReply("vagrant", "1.0.1"))
+				generateReleasesLatestMock("vagrant").Reply(200).
+					BodyString(generateReleasesReply("vagrant", "1.0.2"))
+				generateDispatchMock().
+					MatchType("json").
+					BodyString(`.*"cask":"true".*`).
+					Reply(200).
+					BodyString(caskSuccess)
+				generateDispatchMock().
+					Reply(200).
+					BodyString(formulaSuccess)
+
+				require.NoError(HandleLambdaEvent(generateSnsEvent("vagrant", "1.0.2")))
+				writer.Close()
+				result, err := ioutil.ReadAll(reader)
+				require.NoError(err)
+				require.Contains(string(result), caskSuccess)
+			})
+
+			t.Run("it should trigger formula workflow", func(t *testing.T) {
+				reader, writer, cleanup := enableStdoutCapture(t)
+				defer cleanup()
+				defer gock.Off()
+				generateCaskMock("vagrant").Reply(200).
+					BodyString(generateCaskReply("vagrant", "1.0.1"))
+				generateReleasesLatestMock("vagrant").Reply(200).
+					BodyString(generateReleasesReply("vagrant", "1.0.2"))
+				generateDispatchMock().
+					Reply(200).
+					BodyString(caskSuccess)
+				generateDispatchMock().
+					MatchType("json").
+					BodyString(`.*"cask":"false".*`).
+					Reply(200).
+					BodyString(formulaSuccess)
+
+				require.NoError(HandleLambdaEvent(generateSnsEvent("vagrant", "1.0.2")))
+				writer.Close()
+				result, err := ioutil.ReadAll(reader)
+				require.NoError(err)
+				require.Contains(string(result), formulaSuccess)
+			})
+		})
+
+		t.Run("when versions are the same", func(t *testing.T) {
+			defer gock.Off()
+			generateCaskMock("vagrant").Reply(200).
+				BodyString(generateCaskReply("vagrant", "1.0.1"))
+			generateReleasesLatestMock("vagrant").Reply(200).
+				BodyString(generateReleasesReply("vagrant", "1.0.1"))
+			err := HandleLambdaEvent(generateSnsEvent("vagrant", "1.0.2"))
+			require.Error(err)
+			require.Contains(err.Error(), "latest version")
+		})
+	})
+}
+
+// Captures content written to stdout
+func enableStdoutCapture(t *testing.T) (reader io.ReadCloser, writer io.Closer, cleanup func()) {
+	t.Helper()
+	reader, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Could not setup stdout capture: %s", err)
+	}
+	writer = w
+	stdout := os.Stdout
+	os.Stdout = w
+	cleanup = func() {
+		os.Stdout = stdout
+		reader.Close()
+		writer.Close()
+	}
+	return
+}
+
+// Generate simplified formula content for version checking
+func generateFormulaReply(product, version string) string {
+	return fmt.Sprintf(`desc "%s"\nversion "%s"\n`, product, version)
+}
+
+// Generate simplified cask content for version checking
+// NOTE: hashicorp- prefix is automatically added to product
+func generateCaskReply(product, version string) string {
+	// Casks always have "hashicorp-" prefix so add
+	product = "hashicorp-" + product
+	return fmt.Sprintf(`cask "%s" do\nversion "%s"\nend`, product, version)
+}
+
+// Generates the response body for latest from releases api
+// NOTE: It only includes the name and version values
+func generateReleasesReply(product, version string) string {
+	info := map[string]string{
+		"name":    product,
+		"version": version,
+	}
+	payload, err := json.Marshal(info)
+	if err != nil {
+		panic(err)
+	}
+	return string(payload)
+}
+
+// Generates an SNS event message using provided product and version
+func generateSnsEvent(product, version string) events.SNSEvent {
+	info := map[string]string{
+		"product": product,
+		"version": version,
+	}
+	payload, err := json.Marshal(info)
+	if err != nil {
+		panic(err)
+	}
+
+	return events.SNSEvent{
+		Records: []events.SNSEventRecord{
+			{
+				SNS: events.SNSEntity{
+					Message: string(payload),
+				},
+			},
+		},
+	}
+}
+
+// Generates the base mock used when requesting latest version from the releases api
+func generateReleasesLatestMock(product string) *gock.Request {
+	return gock.New("https://api.releases.hashicorp.com").
+		Get(fmt.Sprintf("/v1/releases/%s/latest", product))
+}
+
+// Generates the base mock used when requesting formula for version check
+func generateFormulaMock(product string) *gock.Request {
+	return gock.New("https://raw.githubusercontent.com").
+		Get(fmt.Sprintf("/hashicorp/homebrew-tap/master/Formula/%s.rb", product))
+}
+
+// Generates the base mock used when requesting cask for version check
+// NOTE: hashicorp- prefix is automatically added to product
+func generateCaskMock(product string) *gock.Request {
+	// Casks always have "hashicorp-" prefix so add
+	product = "hashicorp-" + product
+	return gock.New("https://raw.githubusercontent.com").
+		Get(fmt.Sprintf("/hashicorp/homebrew-tap/master/Casks/%s.rb", product))
+}
+
+// Generates the base mock used when sending a repository dispatch notification
+func generateDispatchMock() *gock.Request {
+	dispatchUrl, err := url.Parse(workflowEndpoint)
+	if err != nil {
+		panic(err)
+	}
+
+	return gock.New(fmt.Sprintf("%s://%s", dispatchUrl.Scheme, dispatchUrl.Host)).
+		Post(dispatchUrl.Path)
 }


### PR DESCRIPTION
Enhancements for handling products with Casks. Quick breakdown of
enhancements included:

### Lambda trigger

* Allow designating products as providing formula and cask
* Support triggering cask and formula events from single SNS

### Formula Templater

* Separate formula and cask definitions within config
* Generate cask contents by using `-cask` flag
* Only include macOS related formula content if macos is included in supported architecture
* Support arm64 and/or amd64 when generating cask contents

### Workflows

* Add `-cask` flag to publish workflows where applicable
