### PR TITLE
feat: allow dynamic configuration of artifact host

### DIFF
--- a/Casks/hashicorp-boundary-desktop.rb
+++ b/Casks/hashicorp-boundary-desktop.rb
@@ -1,11 +1,13 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+release_repository = +ENV["HOMEBREW_HASHICORP_ARTIFACT_REPOSITORY_HOST"] || "https://releases.hashicorp.com"
+
 cask "hashicorp-boundary-desktop" do
   version "1.7.1"
   sha256 "1308d08a5ddb86da04af68f325200ebd33f724cd4c7ea3d609fcf1f0dce36a3e"
 
-  url "https://releases.hashicorp.com/boundary-desktop/#{version}/boundary-desktop_#{version}_darwin_amd64.dmg",
+  url release_repository << "/boundary-desktop/#{version}/boundary-desktop_#{version}_darwin_amd64.dmg",
       verified: "hashicorp.com/boundary-desktop/"
   name "Boundary Desktop"
   desc ""

--- a/Casks/hashicorp-vagrant.rb
+++ b/Casks/hashicorp-vagrant.rb
@@ -1,12 +1,14 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+release_repository = +ENV["HOMEBREW_HASHICORP_ARTIFACT_REPOSITORY_HOST"] || "https://releases.hashicorp.com"
+
 cask "hashicorp-vagrant" do
   version "2.4.0"
   arch arm: "arm64", intel: "amd64"
   sha256 arm: "97806047dfc7e0c3818f946a1c954ab03d8f6d1ae45d1aa43e5bdbd7a8856631",
          intel: "97806047dfc7e0c3818f946a1c954ab03d8f6d1ae45d1aa43e5bdbd7a8856631"
-  url "https://releases.hashicorp.com/vagrant/#{version}/vagrant_#{version}_darwin_#{arch}.dmg",
+  url release_repository << "/vagrant/#{version}/vagrant_#{version}_darwin_#{arch}.dmg",
       verified: "hashicorp.com/vagrant/"
   name "Vagrant"
   desc "Development environment"

--- a/Formula/boundary-enterprise.rb
+++ b/Formula/boundary-enterprise.rb
@@ -2,32 +2,34 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class BoundaryEnterprise < Formula
+  release_repository = +ENV["HOMEBREW_HASHICORP_ARTIFACT_REPOSITORY_HOST"] || "https://releases.hashicorp.com"
+
   desc "Boundary Enterprise"
   homepage "https://www.boundaryproject.io/"
   version "0.14.3+ent"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/boundary/0.14.3+ent/boundary_0.14.3+ent_darwin_amd64.zip"
+    url release_repository << "/boundary/0.14.3+ent/boundary_0.14.3+ent_darwin_amd64.zip"
     sha256 "9c264cda52e919235f9467065e80b81aba673b67d71245a46b17ac7803b8fc2f"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/boundary/0.14.3+ent/boundary_0.14.3+ent_darwin_arm64.zip"
+    url release_repository << "/boundary/0.14.3+ent/boundary_0.14.3+ent_darwin_arm64.zip"
     sha256 "51eff47079322b7a3b0cf92ccb3a4fe533bf41f178b88f13da5502a635bb7731"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/boundary/0.14.3+ent/boundary_0.14.3+ent_linux_amd64.zip"
+    url release_repository << "/boundary/0.14.3+ent/boundary_0.14.3+ent_linux_amd64.zip"
     sha256 "b1364d334d56c4b3535ff192817a5a83c63348ec62e1fa3a63ddebe8f1967647"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/boundary/0.14.3+ent/boundary_0.14.3+ent_linux_arm.zip"
+    url release_repository << "/boundary/0.14.3+ent/boundary_0.14.3+ent_linux_arm.zip"
     sha256 "8ac4765a1c378c76a8eaf8fba6b8e979b7787dfd3c9060188eb02f36e2355f75"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/boundary/0.14.3+ent/boundary_0.14.3+ent_linux_arm64.zip"
+    url release_repository << "/boundary/0.14.3+ent/boundary_0.14.3+ent_linux_arm64.zip"
     sha256 "3ce97701e2737ac01dfbadb3f9a600201291f0ba9b3ac1fb10def4fa40d1565d"
   end
 

--- a/Formula/boundary.rb
+++ b/Formula/boundary.rb
@@ -2,32 +2,34 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class Boundary < Formula
+  release_repository = +ENV["HOMEBREW_HASHICORP_ARTIFACT_REPOSITORY_HOST"] || "https://releases.hashicorp.com"
+
   desc "Boundary"
   homepage "https://www.boundaryproject.io/"
   version "0.14.3"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/boundary/0.14.3/boundary_0.14.3_darwin_amd64.zip"
+    url release_repository << "/boundary/0.14.3/boundary_0.14.3_darwin_amd64.zip"
     sha256 "75e4418b56324f3d95bc8e624bd934ce2bdb228696db33ec2095cb578cfe5e8b"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/boundary/0.14.3/boundary_0.14.3_darwin_arm64.zip"
+    url release_repository << "/boundary/0.14.3/boundary_0.14.3_darwin_arm64.zip"
     sha256 "1d6c9a6405f79c25fdc4c945d69587b4eb639833099ae996d7ae4f4871264769"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/boundary/0.14.3/boundary_0.14.3_linux_amd64.zip"
+    url release_repository << "/boundary/0.14.3/boundary_0.14.3_linux_amd64.zip"
     sha256 "284ffea85f2853b87b783a2d1e6cd4ceb0b0c3ad8d15233cd7d634ce53363327"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/boundary/0.14.3/boundary_0.14.3_linux_arm.zip"
+    url release_repository << "/boundary/0.14.3/boundary_0.14.3_linux_arm.zip"
     sha256 "5173f04e3108e3845f5fa55c8ed85a9c06dd9e4c72fda5d71ad86bc001ddf56e"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/boundary/0.14.3/boundary_0.14.3_linux_arm64.zip"
+    url release_repository << "/boundary/0.14.3/boundary_0.14.3_linux_arm64.zip"
     sha256 "e18b335cdddcffefdc60e496dd39770f5936f7ac014d23cd019a2e7cb7e99dc5"
   end
 

--- a/Formula/consul-aws.rb
+++ b/Formula/consul-aws.rb
@@ -1,4 +1,6 @@
 class ConsulAws < Formula
+  release_repository = +ENV["HOMEBREW_HASHICORP_ARTIFACT_REPOSITORY_HOST"] || "https://releases.hashicorp.com"
+
   desc "Consul AWS"
   homepage "https://github.com/hashicorp/consul-aws"
   version "0.1.2"
@@ -20,12 +22,12 @@ class ConsulAws < Formula
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul-aws/0.1.2/consul-aws_0.1.2_linux_amd64.zip"
+    url release_repository << "/consul-aws/0.1.2/consul-aws_0.1.2_linux_amd64.zip"
     sha256 "c1a44fd4df8c455a6e4279f83938171087901e17fbff46adbe10c9697fbfb503"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul-aws/0.1.2/consul-aws_0.1.2_linux_arm64.zip"
+    url release_repository << "/consul-aws/0.1.2/consul-aws_0.1.2_linux_arm64.zip"
     sha256 "16145d50885aeb6d588b9a35ec4492e5e6960f7c68d4d2f16b0581397e5821f2"
   end
 

--- a/Formula/consul-dataplane.rb
+++ b/Formula/consul-dataplane.rb
@@ -2,35 +2,37 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class ConsulDataplane < Formula
+  release_repository = +ENV["HOMEBREW_HASHICORP_ARTIFACT_REPOSITORY_HOST"] || "https://releases.hashicorp.com"
+
   desc "Consul Dataplane"
   homepage "https://github.com/hashicorp/consul-dataplane"
   version "1.3.1"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul-dataplane/1.3.1/consul-dataplane_1.3.1_darwin_amd64.zip"
+    url release_repository << "/consul-dataplane/1.3.1/consul-dataplane_1.3.1_darwin_amd64.zip"
     sha256 "a44af7b835fb6ac440efdd936d78ddb36c9b4ef2dbe45d2c12ecf1bfc6fe3bef"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/consul-dataplane/1.3.1/consul-dataplane_1.3.1_darwin_arm64.zip"
+    url release_repository << "/consul-dataplane/1.3.1/consul-dataplane_1.3.1_darwin_arm64.zip"
     sha256 "8ed782957d902abf2696f134785847f52e440c892b8d3a1abf36da3cc9d2ef8f"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul-dataplane/1.3.1/consul-dataplane_1.3.1_linux_amd64.zip"
+    url release_repository << "/consul-dataplane/1.3.1/consul-dataplane_1.3.1_linux_amd64.zip"
     sha256 "3c030edca1d47a2051c12937a1c04c189f94cf6574c83ba4368ef42e710618c0"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul-dataplane/1.3.1/consul-dataplane_1.3.1_linux_arm.zip"
+    url release_repository << "/consul-dataplane/1.3.1/consul-dataplane_1.3.1_linux_arm.zip"
     sha256 "f28ed557863e3c7e3002298a1db931a9ac279391a66582290278cb129047818b"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul-dataplane/1.3.1/consul-dataplane_1.3.1_linux_arm64.zip"
+    url release_repository << "/consul-dataplane/1.3.1/consul-dataplane_1.3.1_linux_arm64.zip"
     sha256 "715e82d28d23976702d9473563aee4221af28fdc6a01b9694afd4689780e54dd"
   end
-  
+
   depends_on "envoy" => :recommended
 
   conflicts_with "consul-dataplane"

--- a/Formula/consul-enterprise.rb
+++ b/Formula/consul-enterprise.rb
@@ -2,32 +2,34 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class ConsulEnterprise < Formula
+  release_repository = +ENV["HOMEBREW_HASHICORP_ARTIFACT_REPOSITORY_HOST"] || "https://releases.hashicorp.com"
+
   desc "Consul Enterprise"
   homepage "https://www.consul.io"
   version "1.17.1+ent"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul/1.17.1+ent/consul_1.17.1+ent_darwin_amd64.zip"
+    url release_repository << "/consul/1.17.1+ent/consul_1.17.1+ent_darwin_amd64.zip"
     sha256 "3034dc18ae3bc9e7822e26edec93f6d7b0e8e86b6b6afb94f3adb16413e300da"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/consul/1.17.1+ent/consul_1.17.1+ent_darwin_arm64.zip"
+    url release_repository << "/consul/1.17.1+ent/consul_1.17.1+ent_darwin_arm64.zip"
     sha256 "7f8c35b9964d596f955ebc10485ab10cd978cb4f0187e337fdf3cc3660da2a81"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul/1.17.1+ent/consul_1.17.1+ent_linux_amd64.zip"
+    url release_repository << "/consul/1.17.1+ent/consul_1.17.1+ent_linux_amd64.zip"
     sha256 "0233d76e2352e7bd3529dce90de0e2b9e468f40a4f8e963b7fda2d3a119721ee"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul/1.17.1+ent/consul_1.17.1+ent_linux_arm.zip"
+    url release_repository << "/consul/1.17.1+ent/consul_1.17.1+ent_linux_arm.zip"
     sha256 "35f05983b1c7cf91c70ddd0618c199c65fd679bc4a827048cc45526368f9eba7"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul/1.17.1+ent/consul_1.17.1+ent_linux_arm64.zip"
+    url release_repository << "/consul/1.17.1+ent/consul_1.17.1+ent_linux_arm64.zip"
     sha256 "23d79e71d0157e50ff1b2e04590224e382571918de469265ea80dd615a97fbcd"
   end
 

--- a/Formula/consul-esm.rb
+++ b/Formula/consul-esm.rb
@@ -1,30 +1,32 @@
 class ConsulEsm < Formula
+  release_repository = +ENV["HOMEBREW_HASHICORP_ARTIFACT_REPOSITORY_HOST"] || "https://releases.hashicorp.com"
+
   desc "Consul ESM"
   homepage "https://github.com/hashicorp/consul-esm"
   version "0.7.1"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul-esm/0.7.1/consul-esm_0.7.1_darwin_amd64.zip"
+    url release_repository << "/consul-esm/0.7.1/consul-esm_0.7.1_darwin_amd64.zip"
     sha256 "017d94d565dc3c4769472978b033be354ded1a1b8baf1230225587e9453ce5bf"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/consul-esm/0.7.1/consul-esm_0.7.1_darwin_arm64.zip"
+    url release_repository << "/consul-esm/0.7.1/consul-esm_0.7.1_darwin_arm64.zip"
     sha256 "746e127366c94b8fc6838c877c41d26df65a1ca4936dbbddd596b4ef3d5622e9"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul-esm/0.7.1/consul-esm_0.7.1_linux_amd64.zip"
+    url release_repository << "/consul-esm/0.7.1/consul-esm_0.7.1_linux_amd64.zip"
     sha256 "bc1d8c351d277bb1e93d3d2a209b9282ee5d84e3a82ce3c38281f40318b5268f"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul-esm/0.7.1/consul-esm_0.7.1_linux_arm.zip"
+    url release_repository << "/consul-esm/0.7.1/consul-esm_0.7.1_linux_arm.zip"
     sha256 "01acf7c989820f399effedd75a3bfa189de5e3853b58bb670b070fd9445f8594"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul-esm/0.7.1/consul-esm_0.7.1_linux_arm64.zip"
+    url release_repository << "/consul-esm/0.7.1/consul-esm_0.7.1_linux_arm64.zip"
     sha256 "47e607ef585fb0f4fdffa9de9364e28ecba7a1c9dc80734d4a20f5744d5a37d8"
   end
 

--- a/Formula/consul-k8s.rb
+++ b/Formula/consul-k8s.rb
@@ -2,32 +2,34 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class ConsulK8s < Formula
+  release_repository = +ENV["HOMEBREW_HASHICORP_ARTIFACT_REPOSITORY_HOST"] || "https://releases.hashicorp.com"
+
   desc "Consul K8s"
   homepage "https://github.com/hashicorp/consul-k8s"
   version "1.3.1"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul-k8s/1.3.1/consul-k8s_1.3.1_darwin_amd64.zip"
+    url release_repository << "/consul-k8s/1.3.1/consul-k8s_1.3.1_darwin_amd64.zip"
     sha256 "d25f8ed53018ae93b8127fe7eba5b994b1a960dc65683d9b17885ae70e9c6004"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/consul-k8s/1.3.1/consul-k8s_1.3.1_darwin_arm64.zip"
+    url release_repository << "/consul-k8s/1.3.1/consul-k8s_1.3.1_darwin_arm64.zip"
     sha256 "04e078df553536b866663e5e886ba9ab89bc7bbcef9fec8d445cfd6bba16e4fa"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul-k8s/1.3.1/consul-k8s_1.3.1_linux_amd64.zip"
+    url release_repository << "/consul-k8s/1.3.1/consul-k8s_1.3.1_linux_amd64.zip"
     sha256 "5f92e36742ef6c281a37df3cbf5db8215a6950a0c691cfd4e96a0eafcbcd6b90"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul-k8s/1.3.1/consul-k8s_1.3.1_linux_arm.zip"
+    url release_repository << "/consul-k8s/1.3.1/consul-k8s_1.3.1_linux_arm.zip"
     sha256 "12222288a377cb44653c3a391f715401b91915df8ef685b91dda9a673ca79adf"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul-k8s/1.3.1/consul-k8s_1.3.1_linux_arm64.zip"
+    url release_repository << "/consul-k8s/1.3.1/consul-k8s_1.3.1_linux_arm64.zip"
     sha256 "604817de5279d51c26499b6cb602a7173cc88ab18d5adc627fd13cf4e2fb1aed"
   end
 

--- a/Formula/consul-template.rb
+++ b/Formula/consul-template.rb
@@ -2,32 +2,34 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class ConsulTemplate < Formula
+  release_repository = +ENV["HOMEBREW_HASHICORP_ARTIFACT_REPOSITORY_HOST"] || "https://releases.hashicorp.com"
+
   desc "Consul Template"
   homepage "https://github.com/hashicorp/consul-template"
   version "0.35.0"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul-template/0.35.0/consul-template_0.35.0_darwin_amd64.zip"
+    url release_repository << "/consul-template/0.35.0/consul-template_0.35.0_darwin_amd64.zip"
     sha256 "f527e5dfad80a9ec1aefd09c641dc9128f267f7bb4974e5c6679279317ef774c"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/consul-template/0.35.0/consul-template_0.35.0_darwin_arm64.zip"
+    url release_repository << "/consul-template/0.35.0/consul-template_0.35.0_darwin_arm64.zip"
     sha256 "44a16f6b610694b468131a1310d8f2d4d3fd27ef68b448394e5cacfff38ca15b"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul-template/0.35.0/consul-template_0.35.0_linux_amd64.zip"
+    url release_repository << "/consul-template/0.35.0/consul-template_0.35.0_linux_amd64.zip"
     sha256 "1b1c9127e8da25b2d7322e6f2aa8e6d946336083999e0fdb321f96ffd447eebd"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul-template/0.35.0/consul-template_0.35.0_linux_arm.zip"
+    url release_repository << "/consul-template/0.35.0/consul-template_0.35.0_linux_arm.zip"
     sha256 "c6cd4a94662ee6e8b6b1e9969c3ae96a9f188cd87a60048f2bebc0993a02a399"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul-template/0.35.0/consul-template_0.35.0_linux_arm64.zip"
+    url release_repository << "/consul-template/0.35.0/consul-template_0.35.0_linux_arm64.zip"
     sha256 "758755e94b89cf6d072b66e2c063f5572249fe4a8a931aed8b72173419faaa35"
   end
 

--- a/Formula/consul-terraform-sync.rb
+++ b/Formula/consul-terraform-sync.rb
@@ -2,12 +2,14 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class ConsulTerraformSync < Formula
+  release_repository = +ENV["HOMEBREW_HASHICORP_ARTIFACT_REPOSITORY_HOST"] || "https://releases.hashicorp.com"
+
   desc "Consul Terraform Sync"
   homepage "https://github.com/hashicorp/consul-terraform-sync"
   version "0.7.1"
 
   if OS.mac?
-    url "https://releases.hashicorp.com/consul-terraform-sync/0.7.1/consul-terraform-sync_0.7.1_darwin_amd64.zip"
+    url release_repository << "/consul-terraform-sync/0.7.1/consul-terraform-sync_0.7.1_darwin_amd64.zip"
     sha256 "fc0a19476d28230ea753d11e375f03adc726f14aa12f2ddd89328889a07ff2db"
   end
 
@@ -23,17 +25,17 @@ class ConsulTerraformSync < Formula
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul-terraform-sync/0.7.1/consul-terraform-sync_0.7.1_linux_amd64.zip"
+    url release_repository << "/consul-terraform-sync/0.7.1/consul-terraform-sync_0.7.1_linux_amd64.zip"
     sha256 "afd03bdd150a1949a65b5b48f7d299eab4f2e93639e2957ec792c2b746e34682"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul-terraform-sync/0.7.1/consul-terraform-sync_0.7.1_linux_arm.zip"
+    url release_repository << "/consul-terraform-sync/0.7.1/consul-terraform-sync_0.7.1_linux_arm.zip"
     sha256 "a1f632edbe288171b9402c4f6ba98b32a0e87df208b03dc9a51339078e615d8b"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul-terraform-sync/0.7.1/consul-terraform-sync_0.7.1_linux_arm64.zip"
+    url release_repository << "/consul-terraform-sync/0.7.1/consul-terraform-sync_0.7.1_linux_arm64.zip"
     sha256 "1f942d8d745b8ddecbf565e6ca57bb9ac3a80c26adee7faa0556737844449ad2"
   end
 

--- a/Formula/consul.rb
+++ b/Formula/consul.rb
@@ -2,32 +2,34 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class Consul < Formula
+  release_repository = +ENV["HOMEBREW_HASHICORP_ARTIFACT_REPOSITORY_HOST"] || "https://releases.hashicorp.com"
+
   desc "Consul"
   homepage "https://www.consul.io"
   version "1.17.1"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul/1.17.1/consul_1.17.1_darwin_amd64.zip"
+    url release_repository << "/consul/1.17.1/consul_1.17.1_darwin_amd64.zip"
     sha256 "48313acf9093c8bcf2e57a8535c2dd3d036ba435c340d27f56f23d0fabf3b416"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/consul/1.17.1/consul_1.17.1_darwin_arm64.zip"
+    url release_repository << "/consul/1.17.1/consul_1.17.1_darwin_arm64.zip"
     sha256 "d727d31c00a247b0c0125ffc05bcd4929c5451ef8ee4e844720d641d237f3081"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul/1.17.1/consul_1.17.1_linux_amd64.zip"
+    url release_repository << "/consul/1.17.1/consul_1.17.1_linux_amd64.zip"
     sha256 "388889321d6aaf389ee87acc247ea9885e684a1581c8ebfbeab7348abd7c0214"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul/1.17.1/consul_1.17.1_linux_arm.zip"
+    url release_repository << "/consul/1.17.1/consul_1.17.1_linux_arm.zip"
     sha256 "4cea522a3114c4d7b35ef39fc53a405520b9267691e9a88625559c6c39bf2946"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul/1.17.1/consul_1.17.1_linux_arm64.zip"
+    url release_repository << "/consul/1.17.1/consul_1.17.1_linux_arm64.zip"
     sha256 "f36e1add92439cac710f2546beac97f9a6478fab9ff2342f3ce13f72ef2650de"
   end
 

--- a/Formula/envconsul.rb
+++ b/Formula/envconsul.rb
@@ -2,32 +2,34 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class Envconsul < Formula
+  release_repository = +ENV["HOMEBREW_HASHICORP_ARTIFACT_REPOSITORY_HOST"] || "https://releases.hashicorp.com"
+
   desc "Env Consul"
   homepage "https://github.com/hashicorp/envconsul"
   version "0.13.2"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/envconsul/0.13.2/envconsul_0.13.2_darwin_amd64.zip"
+    url release_repository << "/envconsul/0.13.2/envconsul_0.13.2_darwin_amd64.zip"
     sha256 "0e08ebedc24511f56c4a5b3f16177767289544b0414e1ee2333ee15a04f3dd7b"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/envconsul/0.13.2/envconsul_0.13.2_darwin_arm64.zip"
+    url release_repository << "/envconsul/0.13.2/envconsul_0.13.2_darwin_arm64.zip"
     sha256 "a323e17c2d69e38f1c3da7e8c3a0c0d4da3492d20a40fdcdb719556264fc2962"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/envconsul/0.13.2/envconsul_0.13.2_linux_amd64.zip"
+    url release_repository << "/envconsul/0.13.2/envconsul_0.13.2_linux_amd64.zip"
     sha256 "3a2719ad53e6b180f2accc9cd1b165fdca38a2e11e72504229a1aaaac9e7bd00"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/envconsul/0.13.2/envconsul_0.13.2_linux_arm.zip"
+    url release_repository << "/envconsul/0.13.2/envconsul_0.13.2_linux_arm.zip"
     sha256 "e98e41a87f409e1a9618872e72ef4bf5d1c03f8517f17baa7745f92d7c7d4305"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/envconsul/0.13.2/envconsul_0.13.2_linux_arm64.zip"
+    url release_repository << "/envconsul/0.13.2/envconsul_0.13.2_linux_arm64.zip"
     sha256 "a413d7c6cae56de2b0b7215a64e74ee718a76ad2f9205ce95871340b5d7dfbd9"
   end
 

--- a/Formula/hc-install.rb
+++ b/Formula/hc-install.rb
@@ -2,32 +2,34 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class HcInstall < Formula
+  release_repository = +ENV["HOMEBREW_HASHICORP_ARTIFACT_REPOSITORY_HOST"] || "https://releases.hashicorp.com"
+
   desc "hc-install CLI"
   homepage "https://github.com/hashicorp/hc-install"
   version "0.6.2"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/hc-install/0.6.2/hc-install_0.6.2_darwin_amd64.zip"
+    url release_repository << "/hc-install/0.6.2/hc-install_0.6.2_darwin_amd64.zip"
     sha256 "6481aa34c3979a3e39e0dd0ef7fbd99fd302fd279839ac9530a9edd50e0b49c0"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/hc-install/0.6.2/hc-install_0.6.2_darwin_arm64.zip"
+    url release_repository << "/hc-install/0.6.2/hc-install_0.6.2_darwin_arm64.zip"
     sha256 "af19daf8896ad4258ad39c513ff8b414578765506db71efdfdad9699f46fc0d2"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/hc-install/0.6.2/hc-install_0.6.2_linux_amd64.zip"
+    url release_repository << "/hc-install/0.6.2/hc-install_0.6.2_linux_amd64.zip"
     sha256 "c7f084d1f4829084476c0c54006982682691d89408ff4659f03e05cdfa5a2baf"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/hc-install/0.6.2/hc-install_0.6.2_linux_arm.zip"
+    url release_repository << "/hc-install/0.6.2/hc-install_0.6.2_linux_arm.zip"
     sha256 "4c15a66b0f798879bfe4e91ad287438fa92c66e13dc46669c8fd105888c6d799"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/hc-install/0.6.2/hc-install_0.6.2_linux_arm64.zip"
+    url release_repository << "/hc-install/0.6.2/hc-install_0.6.2_linux_arm64.zip"
     sha256 "49895b4ca7edafcc4f557e577a34c5d0cde86d6dec5cb877ac4fe72e276936ad"
   end
 

--- a/Formula/hcdiag.rb
+++ b/Formula/hcdiag.rb
@@ -2,32 +2,34 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class Hcdiag < Formula
+  release_repository = +ENV["HOMEBREW_HASHICORP_ARTIFACT_REPOSITORY_HOST"] || "https://releases.hashicorp.com"
+
   desc "Hcdiag"
   homepage "https://github.com/hashicorp/hcdiag"
   version "0.5.2"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/hcdiag/0.5.2/hcdiag_0.5.2_darwin_amd64.zip"
+    url release_repository << "/hcdiag/0.5.2/hcdiag_0.5.2_darwin_amd64.zip"
     sha256 "3b3cc79035a0331089e1d9c99787df6c48bb95ba6822b9ff023db4635e356428"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/hcdiag/0.5.2/hcdiag_0.5.2_darwin_arm64.zip"
+    url release_repository << "/hcdiag/0.5.2/hcdiag_0.5.2_darwin_arm64.zip"
     sha256 "287a13a2e9573d04866b9655d5b49ad3963e59b3790ba0e2f83060b3e9913d91"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/hcdiag/0.5.2/hcdiag_0.5.2_linux_amd64.zip"
+    url release_repository << "/hcdiag/0.5.2/hcdiag_0.5.2_linux_amd64.zip"
     sha256 "78efaf950f52193996af67fa15057328b282271a25cc50249b3e201a50c92270"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/hcdiag/0.5.2/hcdiag_0.5.2_linux_arm.zip"
+    url release_repository << "/hcdiag/0.5.2/hcdiag_0.5.2_linux_arm.zip"
     sha256 "5acff8756600a7fce235dd202f4a5bc7d196d90c4076fb67cf173a8a4e6523cf"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/hcdiag/0.5.2/hcdiag_0.5.2_linux_arm64.zip"
+    url release_repository << "/hcdiag/0.5.2/hcdiag_0.5.2_linux_arm64.zip"
     sha256 "d8272c2b6788d75141d867a77ec4a15822ddfec507c6ff8984eccfc584c88f95"
   end
 

--- a/Formula/levant.rb
+++ b/Formula/levant.rb
@@ -2,12 +2,14 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class Levant < Formula
+  release_repository = +ENV["HOMEBREW_HASHICORP_ARTIFACT_REPOSITORY_HOST"] || "https://releases.hashicorp.com"
+
   desc "Levant"
   homepage "https://github.com/hashicorp/levant"
   version "0.3.3"
 
   if OS.mac?
-    url "https://releases.hashicorp.com/levant/0.3.3/levant_0.3.3_darwin_amd64.zip"
+    url release_repository << "/levant/0.3.3/levant_0.3.3_darwin_amd64.zip"
     sha256 "da1f7b45a5a10f8d2387ac40aac7eb52c3dbe6606e9948b51ee0efb82f88c165"
   end
 
@@ -23,17 +25,17 @@ class Levant < Formula
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/levant/0.3.3/levant_0.3.3_linux_amd64.zip"
+    url release_repository << "/levant/0.3.3/levant_0.3.3_linux_amd64.zip"
     sha256 "630c4c0499fdc0b904be22905e18dcd81350f8011ab1494b23f20d06f192d462"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/levant/0.3.3/levant_0.3.3_linux_arm.zip"
+    url release_repository << "/levant/0.3.3/levant_0.3.3_linux_arm.zip"
     sha256 "02c7106dbf788fdc592f30393a44c9fc4103c7ec7b5662eed351425b149e3a7e"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/levant/0.3.3/levant_0.3.3_linux_arm64.zip"
+    url release_repository << "/levant/0.3.3/levant_0.3.3_linux_arm64.zip"
     sha256 "e2e3bf5aed271d848d8aac86b4649594b7f9aa1e11aa4612f5b571f97598bba4"
   end
 

--- a/Formula/nomad-enterprise.rb
+++ b/Formula/nomad-enterprise.rb
@@ -2,32 +2,34 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class NomadEnterprise < Formula
+  release_repository = +ENV["HOMEBREW_HASHICORP_ARTIFACT_REPOSITORY_HOST"] || "https://releases.hashicorp.com"
+
   desc "Nomad Enterprise"
   homepage "https://www.nomadproject.io/"
   version "1.7.2+ent"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/nomad/1.7.2+ent/nomad_1.7.2+ent_darwin_amd64.zip"
+    url release_repository << "/nomad/1.7.2+ent/nomad_1.7.2+ent_darwin_amd64.zip"
     sha256 "56c529a817fafd38b19787e08fd3ce8fa1dbcb5d07ff91d84bf1695a33305ec6"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/nomad/1.7.2+ent/nomad_1.7.2+ent_darwin_arm64.zip"
+    url release_repository << "/nomad/1.7.2+ent/nomad_1.7.2+ent_darwin_arm64.zip"
     sha256 "bfd544c8832458bdff4905e5ff271433c964597bb071c252fd0472d98c70de37"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/nomad/1.7.2+ent/nomad_1.7.2+ent_linux_amd64.zip"
+    url release_repository << "/nomad/1.7.2+ent/nomad_1.7.2+ent_linux_amd64.zip"
     sha256 "2f597048dc6fe71bfb65b88fc3a4177d86a955a3df9154bd71752270682e1bca"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/nomad/1.7.2+ent/nomad_1.7.2+ent_linux_arm.zip"
+    url release_repository << "/nomad/1.7.2+ent/nomad_1.7.2+ent_linux_arm.zip"
     sha256 "6921b84d97c79363625cf9f755aa3ee01867eeed770de026d517da8bb80d5463"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/nomad/1.7.2+ent/nomad_1.7.2+ent_linux_arm64.zip"
+    url release_repository << "/nomad/1.7.2+ent/nomad_1.7.2+ent_linux_arm64.zip"
     sha256 "93a0f2efede5668427eb91b762bf0a6b42a48261b9a1214a012500f8531d868d"
   end
 

--- a/Formula/nomad-pack.rb
+++ b/Formula/nomad-pack.rb
@@ -2,32 +2,34 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class NomadPack < Formula
+  release_repository = +ENV["HOMEBREW_HASHICORP_ARTIFACT_REPOSITORY_HOST"] || "https://releases.hashicorp.com"
+
   desc "Nomad Pack"
   homepage "https://github.com/hashicorp/nomad-pack"
   version "0.1.0"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/nomad-pack/0.1.0/nomad-pack_0.1.0_darwin_amd64.zip"
+    url release_repository << "/nomad-pack/0.1.0/nomad-pack_0.1.0_darwin_amd64.zip"
     sha256 "64c836406dc92859fb2a7ac048f1255e36974ab4225c2b46ffb47b9a0271d637"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/nomad-pack/0.1.0/nomad-pack_0.1.0_darwin_arm64.zip"
+    url release_repository << "/nomad-pack/0.1.0/nomad-pack_0.1.0_darwin_arm64.zip"
     sha256 "b414eec23213c312996c3caa0ce0584579eaa63869e6ff4a50a0bcf171c0c4d2"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/nomad-pack/0.1.0/nomad-pack_0.1.0_linux_amd64.zip"
+    url release_repository << "/nomad-pack/0.1.0/nomad-pack_0.1.0_linux_amd64.zip"
     sha256 "20604ae26caffc506a5f6ad993bc8925f6022d1875c678e91a0897e1a2411288"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/nomad-pack/0.1.0/nomad-pack_0.1.0_linux_arm.zip"
+    url release_repository << "/nomad-pack/0.1.0/nomad-pack_0.1.0_linux_arm.zip"
     sha256 "ce8dd02aa1984767225b45db79fc7152cf0da077774354c5dfabaeff7c2e3855"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/nomad-pack/0.1.0/nomad-pack_0.1.0_linux_arm64.zip"
+    url release_repository << "/nomad-pack/0.1.0/nomad-pack_0.1.0_linux_arm64.zip"
     sha256 "30afcad9d542eb6938d1e8940346958df871fa3353208f7cc13b67e033b12d99"
   end
 

--- a/Formula/nomad.rb
+++ b/Formula/nomad.rb
@@ -2,32 +2,34 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class Nomad < Formula
+  release_repository = +ENV["HOMEBREW_HASHICORP_ARTIFACT_REPOSITORY_HOST"] || "https://releases.hashicorp.com"
+
   desc "Nomad"
   homepage "https://www.nomadproject.io/"
   version "1.7.2"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/nomad/1.7.2/nomad_1.7.2_darwin_amd64.zip"
+    url release_repository << "/nomad/1.7.2/nomad_1.7.2_darwin_amd64.zip"
     sha256 "16c5a5cbccb505972ef2699ae60b8dd411a3ad4a3cebda3add1b15fcef9a8866"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/nomad/1.7.2/nomad_1.7.2_darwin_arm64.zip"
+    url release_repository << "/nomad/1.7.2/nomad_1.7.2_darwin_arm64.zip"
     sha256 "85e976783ca1acf3965dbdfcb5ea0edd48c594739ecece84461f621e930d820f"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/nomad/1.7.2/nomad_1.7.2_linux_amd64.zip"
+    url release_repository << "/nomad/1.7.2/nomad_1.7.2_linux_amd64.zip"
     sha256 "5264b4f4b9a0bf8f086544f15e6a6377c856e5556bf44337c958f5356d251331"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/nomad/1.7.2/nomad_1.7.2_linux_arm.zip"
+    url release_repository << "/nomad/1.7.2/nomad_1.7.2_linux_arm.zip"
     sha256 "c81951736cdd3906e84d065ff2f742f424bf0216e8541a4930055a69698f091d"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/nomad/1.7.2/nomad_1.7.2_linux_arm64.zip"
+    url release_repository << "/nomad/1.7.2/nomad_1.7.2_linux_arm64.zip"
     sha256 "5cdcf9103c8252c83bf1c8540288c3fc2e64b69828beb65395646c76beaff2a0"
   end
 

--- a/Formula/packer.rb
+++ b/Formula/packer.rb
@@ -2,32 +2,34 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class Packer < Formula
+  release_repository = +ENV["HOMEBREW_HASHICORP_ARTIFACT_REPOSITORY_HOST"] || "https://releases.hashicorp.com"
+
   desc "Packer"
   homepage "https://www.packer.io/"
   version "1.10.0"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/packer/1.10.0/packer_1.10.0_darwin_amd64.zip"
+    url release_repository << "/packer/1.10.0/packer_1.10.0_darwin_amd64.zip"
     sha256 "8a2a1ff87b7057b3a62dabc90e6875e6e4a7427098cc266793ae8a8e292e2833"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/packer/1.10.0/packer_1.10.0_darwin_arm64.zip"
+    url release_repository << "/packer/1.10.0/packer_1.10.0_darwin_arm64.zip"
     sha256 "d0cfb884a54d928a5d73150b9a492a5be855105b52b4c50a81059b0beeced408"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/packer/1.10.0/packer_1.10.0_linux_amd64.zip"
+    url release_repository << "/packer/1.10.0/packer_1.10.0_linux_amd64.zip"
     sha256 "a8442e7041db0a7db48f468e353ee07fa6a7b35276ec62f60813c518ca3296c1"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/packer/1.10.0/packer_1.10.0_linux_arm.zip"
+    url release_repository << "/packer/1.10.0/packer_1.10.0_linux_arm.zip"
     sha256 "3b2b97344d13bf25877edfc3ae92e273d2046d811a8174105756edf75e3dba2b"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/packer/1.10.0/packer_1.10.0_linux_arm64.zip"
+    url release_repository << "/packer/1.10.0/packer_1.10.0_linux_arm64.zip"
     sha256 "37149ec9ca322aa50f249a645e43e67498b67e785b356c59f9b0f0e6519da78e"
   end
 

--- a/Formula/sentinel.rb
+++ b/Formula/sentinel.rb
@@ -2,32 +2,34 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class Sentinel < Formula
+  release_repository = +ENV["HOMEBREW_HASHICORP_ARTIFACT_REPOSITORY_HOST"] || "https://releases.hashicorp.com"
+
   desc ""
   homepage "https://docs.hashicorp.com/sentinel"
   version "0.24.0"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/sentinel/0.24.0/sentinel_0.24.0_darwin_amd64.zip"
+    url release_repository << "/sentinel/0.24.0/sentinel_0.24.0_darwin_amd64.zip"
     sha256 "108a9d0cb6531e8beac4a37f98c72a1248d491f0eb5ee09b9a1bf887dd9d871d"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/sentinel/0.24.0/sentinel_0.24.0_darwin_arm64.zip"
+    url release_repository << "/sentinel/0.24.0/sentinel_0.24.0_darwin_arm64.zip"
     sha256 "d79a1823c34e7867b49ccf4a224ec24dff21185466ebb3afa5636c98cc6cffc9"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/sentinel/0.24.0/sentinel_0.24.0_linux_amd64.zip"
+    url release_repository << "/sentinel/0.24.0/sentinel_0.24.0_linux_amd64.zip"
     sha256 "04d4489eff0134a6632a8504b213f0a54f0dca28a7112ba224268cc6bce43986"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/sentinel/0.24.0/sentinel_0.24.0_linux_arm.zip"
+    url release_repository << "/sentinel/0.24.0/sentinel_0.24.0_linux_arm.zip"
     sha256 "9cd2e409d99bf96a0cc872295dd3b475cce82851d3d3bc6c0f2d3276b2412df7"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/sentinel/0.24.0/sentinel_0.24.0_linux_arm64.zip"
+    url release_repository << "/sentinel/0.24.0/sentinel_0.24.0_linux_arm64.zip"
     sha256 "e34bfa125f9328f98c2942769707c292b53ae9578be8b3b5caabe4626a421fb7"
   end
 

--- a/Formula/terraform-ls.rb
+++ b/Formula/terraform-ls.rb
@@ -2,32 +2,34 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class TerraformLs < Formula
+  release_repository = +ENV["HOMEBREW_HASHICORP_ARTIFACT_REPOSITORY_HOST"] || "https://releases.hashicorp.com"
+
   desc "Terraform Language Server"
   homepage "https://github.com/hashicorp/terraform-ls"
   version "0.32.4"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/terraform-ls/0.32.4/terraform-ls_0.32.4_darwin_amd64.zip"
+    url release_repository << "/terraform-ls/0.32.4/terraform-ls_0.32.4_darwin_amd64.zip"
     sha256 "b8c52581d0518b07e03bcafd77953ec9535401d984d8b973795717dd0cd37bd1"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/terraform-ls/0.32.4/terraform-ls_0.32.4_darwin_arm64.zip"
+    url release_repository << "/terraform-ls/0.32.4/terraform-ls_0.32.4_darwin_arm64.zip"
     sha256 "68ebaf2d62562592ffb724291060dc117eb1fac5f9ba5f3bbe3931f870df5c94"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/terraform-ls/0.32.4/terraform-ls_0.32.4_linux_amd64.zip"
+    url release_repository << "/terraform-ls/0.32.4/terraform-ls_0.32.4_linux_amd64.zip"
     sha256 "fd80ca7716c1ed2ef053d5e72382c5d06797fc48bf18e19d10b6550b83947f84"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/terraform-ls/0.32.4/terraform-ls_0.32.4_linux_arm.zip"
+    url release_repository << "/terraform-ls/0.32.4/terraform-ls_0.32.4_linux_arm.zip"
     sha256 "722bbd76bab37dec15365154500ef46cae59b6d6b9d88348947ebf96def43d03"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/terraform-ls/0.32.4/terraform-ls_0.32.4_linux_arm64.zip"
+    url release_repository << "/terraform-ls/0.32.4/terraform-ls_0.32.4_linux_arm64.zip"
     sha256 "840239d16d4c304e67e91581963aa4888c81bd8658b36b538d905a4922172971"
   end
 

--- a/Formula/terraform.rb
+++ b/Formula/terraform.rb
@@ -2,32 +2,34 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class Terraform < Formula
+  release_repository = +ENV["HOMEBREW_HASHICORP_ARTIFACT_REPOSITORY_HOST"] || "https://releases.hashicorp.com"
+
   desc "Terraform"
   homepage "https://www.terraform.io/"
   version "1.6.6"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/terraform/1.6.6/terraform_1.6.6_darwin_amd64.zip"
+    url release_repository << "/terraform/1.6.6/terraform_1.6.6_darwin_amd64.zip"
     sha256 "33376343c7e0279b674c1c8b8a31dc3174ac09dd796d32651cc5e3b98f220436"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/terraform/1.6.6/terraform_1.6.6_darwin_arm64.zip"
+    url release_repository << "/terraform/1.6.6/terraform_1.6.6_darwin_arm64.zip"
     sha256 "01e608fc04cf54869db687a212d60f3dc3d5c828298514857f9e29f8ac1354a9"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/terraform/1.6.6/terraform_1.6.6_linux_amd64.zip"
+    url release_repository << "/terraform/1.6.6/terraform_1.6.6_linux_amd64.zip"
     sha256 "d117883fd98b960c5d0f012b0d4b21801e1aea985e26949c2d1ebb39af074f00"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/terraform/1.6.6/terraform_1.6.6_linux_arm.zip"
+    url release_repository << "/terraform/1.6.6/terraform_1.6.6_linux_arm.zip"
     sha256 "4a5342a4577d462d880bc392e808f453b101a48aaf383baf99383999a2254fc7"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/terraform/1.6.6/terraform_1.6.6_linux_arm64.zip"
+    url release_repository << "/terraform/1.6.6/terraform_1.6.6_linux_arm64.zip"
     sha256 "4066567f4ba031036d9b14c1edb85399aac1cfd6bbec89cdd8c26199adb2793b"
   end
 

--- a/Formula/vagrant.rb
+++ b/Formula/vagrant.rb
@@ -2,12 +2,14 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class Vagrant < Formula
+  release_repository = +ENV["HOMEBREW_HASHICORP_ARTIFACT_REPOSITORY_HOST"] || "https://releases.hashicorp.com"
+
   desc "Development environment"
   homepage "https://www.vagrantup.com/"
   version "2.4.0"
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/vagrant/2.4.0/vagrant_2.4.0_linux_amd64.zip"
+    url release_repository << "/vagrant/2.4.0/vagrant_2.4.0_linux_amd64.zip"
     sha256 "a638c22f9dd35481a4486bdb0eca614ad695036aa444cc3aace4513d3de0cbbe"
   end
 

--- a/Formula/vault-enterprise.rb
+++ b/Formula/vault-enterprise.rb
@@ -2,32 +2,34 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class VaultEnterprise < Formula
+  release_repository = +ENV["HOMEBREW_HASHICORP_ARTIFACT_REPOSITORY_HOST"] || "https://releases.hashicorp.com"
+
   desc "Vault Enterprise"
   homepage "https://www.vaultproject.io"
   version "1.15.4+ent"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/vault/1.15.4+ent/vault_1.15.4+ent_darwin_amd64.zip"
+    url release_repository << "/vault/1.15.4+ent/vault_1.15.4+ent_darwin_amd64.zip"
     sha256 "ee66b311b7d668c14562a75d05eff395fff04dbe9e51549b85ae771fea8c365f"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/vault/1.15.4+ent/vault_1.15.4+ent_darwin_arm64.zip"
+    url release_repository << "/vault/1.15.4+ent/vault_1.15.4+ent_darwin_arm64.zip"
     sha256 "8b55027902ef0df364c6ef42dbf0c04319e8faee00d53339233b80137f01ef26"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/vault/1.15.4+ent/vault_1.15.4+ent_linux_amd64.zip"
+    url release_repository << "/vault/1.15.4+ent/vault_1.15.4+ent_linux_amd64.zip"
     sha256 "4d7711df9a8d280c67f6c30ff45f26c9fd75458649b8a46ffe0ae73304ce32bb"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/vault/1.15.4+ent/vault_1.15.4+ent_linux_arm.zip"
+    url release_repository << "/vault/1.15.4+ent/vault_1.15.4+ent_linux_arm.zip"
     sha256 "f07546676a6cbd85e166ef748e201c2f6d8f6bcd91441cfd146fa1840182baae"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/vault/1.15.4+ent/vault_1.15.4+ent_linux_arm64.zip"
+    url release_repository << "/vault/1.15.4+ent/vault_1.15.4+ent_linux_arm64.zip"
     sha256 "8d2f11d57b1d52d4e9264934e019c5ec542fe4fcbbc579e2b32911ff93de5cd3"
   end
 

--- a/Formula/vault.rb
+++ b/Formula/vault.rb
@@ -2,32 +2,34 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class Vault < Formula
+  release_repository = +ENV["HOMEBREW_HASHICORP_ARTIFACT_REPOSITORY_HOST"] || "https://releases.hashicorp.com"
+
   desc "Vault"
   homepage "https://www.vaultproject.io"
   version "1.15.4"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/vault/1.15.4/vault_1.15.4_darwin_amd64.zip"
+    url release_repository << "/vault/1.15.4/vault_1.15.4_darwin_amd64.zip"
     sha256 "a9d7c6e76d7d5c9be546e9a74860b98db6486fc0df095d8b00bc7f63fb1f6c1c"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/vault/1.15.4/vault_1.15.4_darwin_arm64.zip"
+    url release_repository << "/vault/1.15.4/vault_1.15.4_darwin_arm64.zip"
     sha256 "4bf594a231bef07fbcfbf7329c8004acb8d219ce6a7aff186e0bac7027a0ab25"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/vault/1.15.4/vault_1.15.4_linux_amd64.zip"
+    url release_repository << "/vault/1.15.4/vault_1.15.4_linux_amd64.zip"
     sha256 "f42f550713e87cceef2f29a4e2b754491697475e3d26c0c5616314e40edd8e1b"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/vault/1.15.4/vault_1.15.4_linux_arm.zip"
+    url release_repository << "/vault/1.15.4/vault_1.15.4_linux_arm.zip"
     sha256 "5b2428e6af56d7e9f4fa2a2cc840091035407be8e79adf07a6eb7c30f97f7a12"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/vault/1.15.4/vault_1.15.4_linux_arm64.zip"
+    url release_repository << "/vault/1.15.4/vault_1.15.4_linux_arm64.zip"
     sha256 "79aee168078eb8c0dbb31c283e1136a7575f59fe36fccbb1f1ef6a16e0b67fdb"
   end
 

--- a/Formula/vlt.rb
+++ b/Formula/vlt.rb
@@ -2,32 +2,34 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class Vlt < Formula
+  release_repository = +ENV["HOMEBREW_HASHICORP_ARTIFACT_REPOSITORY_HOST"] || "https://releases.hashicorp.com"
+
   desc "Vlt CLI"
   homepage "https://github.com/hashicorp/vlt"
   version "1.0.0"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/vlt/1.0.0/vlt_1.0.0_darwin_amd64.zip"
+    url release_repository << "/vlt/1.0.0/vlt_1.0.0_darwin_amd64.zip"
     sha256 "47b0c99cc88fd5e8e0de60f283f86d0f5d9ba46dd10bb4a6c3c6e29eefdfe1db"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/vlt/1.0.0/vlt_1.0.0_darwin_arm64.zip"
+    url release_repository << "/vlt/1.0.0/vlt_1.0.0_darwin_arm64.zip"
     sha256 "c6e090f1d93c9977b039281d247aa66d91737ea0767547b20776635aa9eeaa69"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/vlt/1.0.0/vlt_1.0.0_linux_amd64.zip"
+    url release_repository << "/vlt/1.0.0/vlt_1.0.0_linux_amd64.zip"
     sha256 "1a7ab59cb16446f39412d85cab24ec729986ca6ac0f7a49d0ae210e279024bf2"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/vlt/1.0.0/vlt_1.0.0_linux_arm.zip"
+    url release_repository << "/vlt/1.0.0/vlt_1.0.0_linux_arm.zip"
     sha256 "654f987b50f55654daf05d0f644a85ab625bf66282b7b9e9aa883e88b56ef9fd"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/vlt/1.0.0/vlt_1.0.0_linux_arm64.zip"
+    url release_repository << "/vlt/1.0.0/vlt_1.0.0_linux_arm64.zip"
     sha256 "e20529046b9a24fac9bc5d271c13db745d181c55ceed285f8d36af61a562143e"
   end
 

--- a/Formula/waypoint.rb
+++ b/Formula/waypoint.rb
@@ -2,32 +2,34 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class Waypoint < Formula
+  release_repository = +ENV["HOMEBREW_HASHICORP_ARTIFACT_REPOSITORY_HOST"] || "https://releases.hashicorp.com"
+
   desc "Waypoint"
   homepage "https://www.waypointproject.io/"
   version "0.11.4"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/waypoint/0.11.4/waypoint_0.11.4_darwin_amd64.zip"
+    url release_repository << "/waypoint/0.11.4/waypoint_0.11.4_darwin_amd64.zip"
     sha256 "8942a7d00aaf0b39cec05e2f7da8788a2be0f2be0084236d228d031c6e56521f"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/waypoint/0.11.4/waypoint_0.11.4_darwin_arm64.zip"
+    url release_repository << "/waypoint/0.11.4/waypoint_0.11.4_darwin_arm64.zip"
     sha256 "c23da6fe2ba4db6f63963ef2e72caa71faae70b4f598d439d6f35d6abb79f557"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/waypoint/0.11.4/waypoint_0.11.4_linux_amd64.zip"
+    url release_repository << "/waypoint/0.11.4/waypoint_0.11.4_linux_amd64.zip"
     sha256 "96d314f1bc182a30ca9e93910981fbd4ecf7290763c55d2d4e8ddce2b23abdca"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/waypoint/0.11.4/waypoint_0.11.4_linux_arm.zip"
+    url release_repository << "/waypoint/0.11.4/waypoint_0.11.4_linux_arm.zip"
     sha256 "81f9cb034cd8107dc5972130e379559c384249fe068a00653fc11c3bbb98ca31"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/waypoint/0.11.4/waypoint_0.11.4_linux_arm64.zip"
+    url release_repository << "/waypoint/0.11.4/waypoint_0.11.4_linux_arm64.zip"
     sha256 "bbf331be8785a99a0bfcb4707a013355ba58516d0e9b1b78fd8808e4d2213e66"
   end
 


### PR DESCRIPTION
The change replaces static references to `releases.hashicorp.com` with a configurable environment variable that defaults to `releases.hashicorp.com`.

This allows a user to do the following `HOMEBREW_HASHICORP_ARTIFACT_REPOSITORY_HOST="https://my.hashicorp.releases.mirror" brew install terraform` and the zip would be retrieved from the host of the user's configuration instead of `releases.hashicorp.com`

## Who would use this and why

For those developing in environments with limited or restricted access to the public internet (i.e. behind corporate firewalls), external artifacts like the ones hosted on `releases.hashicorp.com` may often be made available on private systems via mirrors or proxies or rehosted entirely.

In these scenarios where direct access to the canonical releases repository is unavailable, to use homebrew successfully with these "hashicorp mirrors", it is a requirement to deploy a MODIFIED fork of this tap repo, swapping the static references to `releases.hashicorp.com` for references to the mirror / proxy / private artifact host. The need for these modifications from the public tap is what I'm trying to eliminate by making these formula more configurable.

With this configuration option available, this tap can be pulled into private environments UNMODIFIED, presumably eliminating the need for modifications or any effort to make them.

### What about the copywrite formula?

The copywrite formula is a bit of an outlier in this repo. It has a unique artifact host (github releases), and it has a "This file was generated by GoReleaser. DO NOT EDIT." comment at the top. I chose to heed that instruction and left it alone. Willing to hear feedback if there's desire to add another environment variable there.