### PR TITLE
vagrant: fix for errors on macOS

### DIFF
--- a/Formula/vagrant.rb
+++ b/Formula/vagrant.rb
@@ -4,20 +4,23 @@
 class Vagrant < Formula
   desc "Development environment"
   homepage "https://www.vagrantup.com/"
+  url "https://releases.hashicorp.com/vagrant/2.4.1/vagrant_2.4.1_linux_amd64.zip"
   version "2.4.1"
+  sha256 "73a3dacf3f36fb4af8ef514aeff245833d086430614f0c183be7e263553dd7c2"
 
-  if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/vagrant/2.4.1/vagrant_2.4.1_linux_amd64.zip"
-    sha256 "73a3dacf3f36fb4af8ef514aeff245833d086430614f0c183be7e263553dd7c2"
-  end
+  depends_on arch: :x86_64
+  depends_on :linux
 
-  conflicts_with "vagrant"
+  conflicts_with cask: [
+    "hashicorp-vagrant",
+    "vagrant",
+  ]
 
   def install
     bin.install "vagrant"
   end
 
   test do
-    system "#{bin}/vagrant --version"
+    system "#{bin}/vagrant", "--version"
   end
 end


### PR DESCRIPTION
Gating the URL behind an if statement causes errors on any macOS Homebrew installation that uses this tap. Instead, use `depends_on` to ensure only Linux on Intel can install it.

For example:
```console
$ brew readall hashicorp/tap
Error: Invalid formula (sonoma): /usr/local/Homebrew/Library/Taps/hashicorp/homebrew-tap/Formula/vagrant.rb
formulae require at least a URL
Error: Invalid formula (arm64_sonoma): /usr/local/Homebrew/Library/Taps/hashicorp/homebrew-tap/Formula/vagrant.rb
formulae require at least a URL
Error: Invalid formula (ventura): /usr/local/Homebrew/Library/Taps/hashicorp/homebrew-tap/Formula/vagrant.rb
formulae require at least a URL
Error: Invalid formula (arm64_ventura): /usr/local/Homebrew/Library/Taps/hashicorp/homebrew-tap/Formula/vagrant.rb
formulae require at least a URL
…
```