### PR TITLE
Add tfstacks to brew tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ brew install hashicorp/tap/packer
 brew install hashicorp/tap/sentinel
 brew install hashicorp/tap/terraform
 brew install hashicorp/tap/terraform-ls
+brew install hashicorp/tap/tfstacks
 brew install hashicorp/tap/vault
 brew install hashicorp/tap/vault-enterprise
 brew install hashicorp/tap/waypoint

--- a/util/formula_templater/config.hcl
+++ b/util/formula_templater/config.hcl
@@ -272,8 +272,8 @@ formula {
 
 formula {
     product = "tfstacks"
-    name = "Terraform Stacks"
-    desc = "Terraform Stacks"
+    name = "Terraform Stacks CLI"
+    desc = "Terraform Stacks CLI"
     homepage = "https://www.terraform.io/"
     architectures {
         darwin_amd64 = true

--- a/util/formula_templater/config.hcl
+++ b/util/formula_templater/config.hcl
@@ -271,6 +271,20 @@ formula {
 }
 
 formula {
+    product = "tfstacks"
+    name = "Terraform Stacks"
+    desc = "Terraform Stacks"
+    homepage = "https://www.terraform.io/"
+    architectures {
+        darwin_amd64 = true
+        darwin_arm64 = true
+        linux_amd64 = true
+        linux_arm = true
+        linux_arm64 = true
+    }
+}
+
+formula {
     product = "vault"
     name = "Vault"
     desc = "Vault"

--- a/util/lambda_trigger/lambda_trigger.go
+++ b/util/lambda_trigger/lambda_trigger.go
@@ -54,6 +54,7 @@ func isProductSupported(product string) bool {
 		"nomad-pack",
 		"terraform",
 		"terraform-ls",
+		"tfstacks",
 		"packer",
 		"boundary",
 		"boundary-enterprise",


### PR DESCRIPTION
Add tfstacks to Hashicorp Homebrew tap.

I notice most of the other PRs adding products here also create a file within the `Formula/` directory. We haven't yet released a single version of `tfstacks` so we don't have release URLs or a version number or SHA256 hashes yet. I'm not sure what the right approach here would be? Should we wait until at least one version has released before merging this, or will it just create the target file instead of updating it during the release process? Thanks!