### PR TITLE
class name should match the ruby file name

### DIFF
--- a/Formula/tfstacks.rb
+++ b/Formula/tfstacks.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-class TerraformStacksCLI < Formula
+class Tfstacks < Formula
   desc "Terraform Stacks CLI"
   homepage "https://www.terraform.io/"
   version "0.1.0"

--- a/util/formula_templater/config.hcl
+++ b/util/formula_templater/config.hcl
@@ -272,7 +272,7 @@ formula {
 
 formula {
     product = "tfstacks"
-    name = "TerraformStacksCLI"
+    name = "Tfstacks"
     desc = "Terraform Stacks CLI"
     homepage = "https://www.terraform.io/"
     architectures {


### PR DESCRIPTION
To fix:
```
Error: No available formula with the name "hashicorp/tap/tfstacks". Did you mean hashicorp/tap/packer?
In formula file: /usr/local/Homebrew/Library/Taps/hashicorp/homebrew-tap/Formula/tfstacks.rb
Expected to find class Tfstacks, but only found: TerraformStacksCLI.
```