### PR TITLE
 RELENG-1105 - Migrate provided al2 runtime

### DIFF
--- a/util/lambda_trigger/Makefile
+++ b/util/lambda_trigger/Makefile
@@ -16,10 +16,10 @@ build: *.go go.* mod-download
 
 release: *.go go.* mod-download
 	@echo "Preparing artifact..."
-	@GOOS=linux GOARCH=amd64 go build -trimpath
-	@touch -d $$(TZ=UTC0 git show --quiet --date='format-local:%Y-%m-%dT%H:%M:%SZ' --format="%cd") lambda_trigger
-	@zip -X lambda.zip lambda_trigger
-	@openssl dgst -sha256 -hex lambda_trigger lambda.zip
+	@GOOS=linux GOARCH=amd64 go build -trimpath -tags lambda.norpc -o bootstrap
+	@touch -d $$(TZ=UTC0 git show --quiet --date='format-local:%Y-%m-%dT%H:%M:%SZ' --format="%cd") bootstrap
+	@zip -X lambda.zip bootstrap
+	@openssl dgst -sha256 -hex bootstrap lambda.zip
 	@echo
 	@echo "AWS Lambda CodeSha256:"
 	@openssl dgst -sha256 -binary lambda.zip | openssl enc -base64


### PR DESCRIPTION
https://hashicorp.atlassian.net/browse/RELENG-1105

Update  lambda to use the `provided.al2` runtime ahead of the go1.x EOL on December 31st.

https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/

This has been deployed locally (with the instructions from [here](https://hashicorp.atlassian.net/wiki/spaces/RELENG/pages/2157904030/Linux+Repos+and+Homebrew#There's-a-bug-in-the-lambda-and-I-have-to-update-it)), manually configured in the lambda UI as per the instructions in the link above and then tested by publishing to the topic:
`aws sns publish --topic-arn=arn:aws:sns:us-east-1:437820160095:manual-release-trigger --message='{"product": "vagrant"}'`
