### PR TITLE
Update publish-homebrew-lambda.yml

### DIFF
--- a/.github/workflows/publish-homebrew-lambda.yml
+++ b/.github/workflows/publish-homebrew-lambda.yml
@@ -12,4 +12,5 @@ jobs:
         with:
           workflow: homebrew-lambda-update.yml
           repo: hashicorp/releng-support
+          ref: main
           token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}


### PR DESCRIPTION
Apparently the ref that triggered the workflow (master) is used by default instead of the default branch on the target repo, weird.