### PR TITLE
feat: allow configuring custom remote to download

### DIFF
--- a/Casks/hashicorp-boundary-desktop.rb
+++ b/Casks/hashicorp-boundary-desktop.rb
@@ -5,7 +5,7 @@ cask "hashicorp-boundary-desktop" do
   version "2.0.3"
   sha256 "2060faa36deea45bdcdd0ce63d06675491829552df7a02013e6f49b77c4352e0"
 
-  url "https://releases.hashicorp.com/boundary-desktop/#{version}/boundary-desktop_#{version}_darwin_amd64.dmg",
+  url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/boundary-desktop/#{version}/boundary-desktop_#{version}_darwin_amd64.dmg",
       verified: "hashicorp.com/boundary-desktop/"
   name "Boundary Desktop"
   desc ""

--- a/Casks/hashicorp-vagrant.rb
+++ b/Casks/hashicorp-vagrant.rb
@@ -6,7 +6,7 @@ cask "hashicorp-vagrant" do
   arch arm: "arm64", intel: "amd64"
   sha256 arm: "881953f7d4cea45aa8b2f2c6c8f5714c2ad4586edd17c6faeb163c6ebed2918e",
          intel: "881953f7d4cea45aa8b2f2c6c8f5714c2ad4586edd17c6faeb163c6ebed2918e"
-  url "https://releases.hashicorp.com/vagrant/#{version}/vagrant_#{version}_darwin_#{arch}.dmg",
+  url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/vagrant/#{version}/vagrant_#{version}_darwin_#{arch}.dmg",
       verified: "hashicorp.com/vagrant/"
   name "Vagrant"
   desc "Development environment"

--- a/Formula/boundary-enterprise.rb
+++ b/Formula/boundary-enterprise.rb
@@ -7,27 +7,27 @@ class BoundaryEnterprise < Formula
   version "0.16.2+ent"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/boundary/0.16.2+ent/boundary_0.16.2+ent_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/boundary/0.16.2+ent/boundary_0.16.2+ent_darwin_amd64.zip"
     sha256 "e5933f71c327b9a81637340765f47b37d3ac1883b7cc7b21b21c457dbb9d8347"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/boundary/0.16.2+ent/boundary_0.16.2+ent_darwin_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/boundary/0.16.2+ent/boundary_0.16.2+ent_darwin_arm64.zip"
     sha256 "0f3f26f185ed58457ade4e4136cb8f8bf0973ef6ecbb62311bcd115be508ed08"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/boundary/0.16.2+ent/boundary_0.16.2+ent_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/boundary/0.16.2+ent/boundary_0.16.2+ent_linux_amd64.zip"
     sha256 "2b764bc546bf85b82fd884e57a6d712c0c366bdab4dc6801fdc27c3438c609df"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/boundary/0.16.2+ent/boundary_0.16.2+ent_linux_arm.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/boundary/0.16.2+ent/boundary_0.16.2+ent_linux_arm.zip"
     sha256 "5776f45265806386e820b83a58ca3945857d45fce05cae4868fb055cd0c92184"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/boundary/0.16.2+ent/boundary_0.16.2+ent_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/boundary/0.16.2+ent/boundary_0.16.2+ent_linux_arm64.zip"
     sha256 "2bc427299fb4c77abe8de9bbcd572605e2aedf67ab4a7e9ea4f495f7c6d0b7c1"
   end
 

--- a/Formula/boundary.rb
+++ b/Formula/boundary.rb
@@ -7,27 +7,27 @@ class Boundary < Formula
   version "0.16.2"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/boundary/0.16.2/boundary_0.16.2_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/boundary/0.16.2/boundary_0.16.2_darwin_amd64.zip"
     sha256 "29478c2b34ac186c1e3a490afe4c465ec0e945a63659ef4d1d9906966fb5add7"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/boundary/0.16.2/boundary_0.16.2_darwin_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/boundary/0.16.2/boundary_0.16.2_darwin_arm64.zip"
     sha256 "727352fb0dd16ee7e7f3f61bf51ad1c14a8359d3ef5c4bccac929511796e3284"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/boundary/0.16.2/boundary_0.16.2_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/boundary/0.16.2/boundary_0.16.2_linux_amd64.zip"
     sha256 "42618e2f1f0e413ad8a9abc5d731dd425b135446e8f007e38057132b51b066d3"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/boundary/0.16.2/boundary_0.16.2_linux_arm.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/boundary/0.16.2/boundary_0.16.2_linux_arm.zip"
     sha256 "e146204bef6c0d37d5c866f1d0fbe1e6ac10b19c174454dd09d1577e3133d944"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/boundary/0.16.2/boundary_0.16.2_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/boundary/0.16.2/boundary_0.16.2_linux_arm64.zip"
     sha256 "541a530f3da2e79aa054d0812790c2c60a75225ff5e89c316b4e3a26a0833685"
   end
 

--- a/Formula/consul-aws.rb
+++ b/Formula/consul-aws.rb
@@ -7,7 +7,7 @@ class ConsulAws < Formula
   version "0.1.3"
 
   if OS.mac?
-    url "https://releases.hashicorp.com/consul-aws/0.1.3/consul-aws_0.1.3_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul-aws/0.1.3/consul-aws_0.1.3_darwin_amd64.zip"
     sha256 "41c57011b30233ae972428f2e57f11ee656138b116982bbcb6bf5a3e138e7510"
   end
 
@@ -23,12 +23,12 @@ class ConsulAws < Formula
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul-aws/0.1.3/consul-aws_0.1.3_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul-aws/0.1.3/consul-aws_0.1.3_linux_amd64.zip"
     sha256 "041d14c0219b13f109745bc97818fd235afde2badff6264d9132438d0a03fdf0"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul-aws/0.1.3/consul-aws_0.1.3_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul-aws/0.1.3/consul-aws_0.1.3_linux_arm64.zip"
     sha256 "a6a2c3e9e480da2c57da7cfbfc7bfadfcc8a2df654fc3fc92330f255fae497a8"
   end
 

--- a/Formula/consul-dataplane.rb
+++ b/Formula/consul-dataplane.rb
@@ -7,27 +7,27 @@ class ConsulDataplane < Formula
   version "1.5.0"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul-dataplane/1.5.0/consul-dataplane_1.5.0_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul-dataplane/1.5.0/consul-dataplane_1.5.0_darwin_amd64.zip"
     sha256 "8ac86a5d543442b54993c10c743331b20cdece045d99be26e2a611908b6003ee"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/consul-dataplane/1.5.0/consul-dataplane_1.5.0_darwin_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul-dataplane/1.5.0/consul-dataplane_1.5.0_darwin_arm64.zip"
     sha256 "dff35269ebb5baf408c1b63a7fd8f545b58236cdcf90560a6665417276467fec"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul-dataplane/1.5.0/consul-dataplane_1.5.0_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul-dataplane/1.5.0/consul-dataplane_1.5.0_linux_amd64.zip"
     sha256 "94b2f0fdd7f8bd7ab112adafbc7edda8a6a1988c13482178871262c2464d229d"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul-dataplane/1.5.0/consul-dataplane_1.5.0_linux_arm.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul-dataplane/1.5.0/consul-dataplane_1.5.0_linux_arm.zip"
     sha256 "25047db84d49520f5818494b42ad2855f0f8d498eaba6087e0920e7b134a42d4"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul-dataplane/1.5.0/consul-dataplane_1.5.0_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul-dataplane/1.5.0/consul-dataplane_1.5.0_linux_arm64.zip"
     sha256 "8a6963618bc7fa0a1a5cbbd98ac764a3f08241c907535cbba509fe073759947f"
   end
   

--- a/Formula/consul-enterprise.rb
+++ b/Formula/consul-enterprise.rb
@@ -7,27 +7,27 @@ class ConsulEnterprise < Formula
   version "1.19.0+ent"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul/1.19.0+ent/consul_1.19.0+ent_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul/1.19.0+ent/consul_1.19.0+ent_darwin_amd64.zip"
     sha256 "63aa035bad22ffce0fff1bd9f4c80ceef970afc53b004ec0fa810cebc4eb19a3"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/consul/1.19.0+ent/consul_1.19.0+ent_darwin_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul/1.19.0+ent/consul_1.19.0+ent_darwin_arm64.zip"
     sha256 "b0ec9960f1af3351918bbaa58787fe434121c4b1d9248536ec53423f5c8f904c"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul/1.19.0+ent/consul_1.19.0+ent_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul/1.19.0+ent/consul_1.19.0+ent_linux_amd64.zip"
     sha256 "e583b6ef4b93fbb66d57248ae4da7f842fbe1171d6c37679cc93005d872a8765"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul/1.19.0+ent/consul_1.19.0+ent_linux_arm.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul/1.19.0+ent/consul_1.19.0+ent_linux_arm.zip"
     sha256 "cbf82ec50088649b4439a333829ada2e75200b0b9c5fafed8e133d988dfa0d0c"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul/1.19.0+ent/consul_1.19.0+ent_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul/1.19.0+ent/consul_1.19.0+ent_linux_arm64.zip"
     sha256 "081a47431dcb7f314818901fe268d155df3d2a50ae519c445918c003eae7de7d"
   end
 

--- a/Formula/consul-esm.rb
+++ b/Formula/consul-esm.rb
@@ -7,27 +7,27 @@ class ConsulEsm < Formula
   version "0.7.2"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul-esm/0.7.2/consul-esm_0.7.2_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul-esm/0.7.2/consul-esm_0.7.2_darwin_amd64.zip"
     sha256 "79145ce7dc6a48965a5f6ff94428bd2ccc9b465bc0d81113cd22cd3114fde942"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/consul-esm/0.7.2/consul-esm_0.7.2_darwin_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul-esm/0.7.2/consul-esm_0.7.2_darwin_arm64.zip"
     sha256 "7ecdab10e4a7f2533aaf0c9909b0a6a2c52f99c899447dd9c8dfece8742ca86d"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul-esm/0.7.2/consul-esm_0.7.2_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul-esm/0.7.2/consul-esm_0.7.2_linux_amd64.zip"
     sha256 "c6ad998ac5599eacddc54800355c39d289e486f5a61e3d92a5580895e4e8bdd5"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul-esm/0.7.2/consul-esm_0.7.2_linux_arm.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul-esm/0.7.2/consul-esm_0.7.2_linux_arm.zip"
     sha256 "f98d817f643621cb377c9abc5486b2edfae8c885a1831450595b74ae7bc0e2cb"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul-esm/0.7.2/consul-esm_0.7.2_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul-esm/0.7.2/consul-esm_0.7.2_linux_arm64.zip"
     sha256 "e4ced673bbf2c70931301a3f5a5daaa1450a82876096c4f1177a20f02edf7683"
   end
 

--- a/Formula/consul-k8s.rb
+++ b/Formula/consul-k8s.rb
@@ -7,27 +7,27 @@ class ConsulK8s < Formula
   version "1.5.0"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul-k8s/1.5.0/consul-k8s_1.5.0_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul-k8s/1.5.0/consul-k8s_1.5.0_darwin_amd64.zip"
     sha256 "9b7202367568388d4ae9b114576f9a4a1a97c68392e4583d8fbd756f79f3583c"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/consul-k8s/1.5.0/consul-k8s_1.5.0_darwin_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul-k8s/1.5.0/consul-k8s_1.5.0_darwin_arm64.zip"
     sha256 "de6d804d059cc90f77c1dd26dc7e3368107a18c93106f630e42a7d27b83ca7c7"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul-k8s/1.5.0/consul-k8s_1.5.0_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul-k8s/1.5.0/consul-k8s_1.5.0_linux_amd64.zip"
     sha256 "9618759e54d9b0add8fbed0bc3caa78c3f68db8830636e70b95efbe1047ae5ee"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul-k8s/1.5.0/consul-k8s_1.5.0_linux_arm.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul-k8s/1.5.0/consul-k8s_1.5.0_linux_arm.zip"
     sha256 "725b2e61a7685276c33669f0abadfc9575dd58d8a36c1fedfffe30ae7f26573c"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul-k8s/1.5.0/consul-k8s_1.5.0_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul-k8s/1.5.0/consul-k8s_1.5.0_linux_arm64.zip"
     sha256 "9f4b62d9c359c45bd4e4c80ee964e161cbe9e2e2ed4cd3106201854dc6985cc3"
   end
 

--- a/Formula/consul-template.rb
+++ b/Formula/consul-template.rb
@@ -7,27 +7,27 @@ class ConsulTemplate < Formula
   version "0.39.0"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul-template/0.39.0/consul-template_0.39.0_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul-template/0.39.0/consul-template_0.39.0_darwin_amd64.zip"
     sha256 "5e773e01009892e5645b6e08e3380e132987fdecdb24221ed283bf60ddbc7e02"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/consul-template/0.39.0/consul-template_0.39.0_darwin_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul-template/0.39.0/consul-template_0.39.0_darwin_arm64.zip"
     sha256 "b6d8c6d59e2b9a1d3f02b4f653322f940192ab47553f2810a0fab152e81a7232"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul-template/0.39.0/consul-template_0.39.0_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul-template/0.39.0/consul-template_0.39.0_linux_amd64.zip"
     sha256 "10e7eba0acc307ab6500e49f75bdb95d8c7273266822e936f78a1c72425e7f4f"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul-template/0.39.0/consul-template_0.39.0_linux_arm.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul-template/0.39.0/consul-template_0.39.0_linux_arm.zip"
     sha256 "0a200e8a149489714811b83f3aa2623f2d8f00478311d292565c381718c94160"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul-template/0.39.0/consul-template_0.39.0_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul-template/0.39.0/consul-template_0.39.0_linux_arm64.zip"
     sha256 "6e5f6880fef6b08348d8d68e6027d25742c8576367f8a6714da1b8ff79fb9c85"
   end
 

--- a/Formula/consul-terraform-sync.rb
+++ b/Formula/consul-terraform-sync.rb
@@ -7,7 +7,7 @@ class ConsulTerraformSync < Formula
   version "0.7.1"
 
   if OS.mac?
-    url "https://releases.hashicorp.com/consul-terraform-sync/0.7.1/consul-terraform-sync_0.7.1_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul-terraform-sync/0.7.1/consul-terraform-sync_0.7.1_darwin_amd64.zip"
     sha256 "fc0a19476d28230ea753d11e375f03adc726f14aa12f2ddd89328889a07ff2db"
   end
 
@@ -23,17 +23,17 @@ class ConsulTerraformSync < Formula
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul-terraform-sync/0.7.1/consul-terraform-sync_0.7.1_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul-terraform-sync/0.7.1/consul-terraform-sync_0.7.1_linux_amd64.zip"
     sha256 "afd03bdd150a1949a65b5b48f7d299eab4f2e93639e2957ec792c2b746e34682"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul-terraform-sync/0.7.1/consul-terraform-sync_0.7.1_linux_arm.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul-terraform-sync/0.7.1/consul-terraform-sync_0.7.1_linux_arm.zip"
     sha256 "a1f632edbe288171b9402c4f6ba98b32a0e87df208b03dc9a51339078e615d8b"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul-terraform-sync/0.7.1/consul-terraform-sync_0.7.1_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul-terraform-sync/0.7.1/consul-terraform-sync_0.7.1_linux_arm64.zip"
     sha256 "1f942d8d745b8ddecbf565e6ca57bb9ac3a80c26adee7faa0556737844449ad2"
   end
 

--- a/Formula/consul.rb
+++ b/Formula/consul.rb
@@ -7,27 +7,27 @@ class Consul < Formula
   version "1.19.0"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul/1.19.0/consul_1.19.0_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul/1.19.0/consul_1.19.0_darwin_amd64.zip"
     sha256 "1a1152eb5739d2bc2cdb0bf85d7fa67457ce5af550897d3b7d9183ad79a0e142"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/consul/1.19.0/consul_1.19.0_darwin_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul/1.19.0/consul_1.19.0_darwin_arm64.zip"
     sha256 "02b6bbc76dae9b49a610af7f0f1caea65965e8fa9b126a75c7085cc3474da20b"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul/1.19.0/consul_1.19.0_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul/1.19.0/consul_1.19.0_linux_amd64.zip"
     sha256 "e337fba12295fc7bab177a84a7616eb8bcc827f032a2982c8c0e417fbe86541f"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul/1.19.0/consul_1.19.0_linux_arm.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul/1.19.0/consul_1.19.0_linux_arm.zip"
     sha256 "5d8d9a024ce54d74f3867b5bd09e93522728f5bfbe4bb6bb5e90ab630684eb92"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul/1.19.0/consul_1.19.0_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul/1.19.0/consul_1.19.0_linux_arm64.zip"
     sha256 "6956d1bf8070a37fdbdbdfc018fb7aad7ab24ea9867d0f05dad35c7e26a43f33"
   end
 

--- a/Formula/envconsul.rb
+++ b/Formula/envconsul.rb
@@ -7,27 +7,27 @@ class Envconsul < Formula
   version "0.13.2"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/envconsul/0.13.2/envconsul_0.13.2_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/envconsul/0.13.2/envconsul_0.13.2_darwin_amd64.zip"
     sha256 "0e08ebedc24511f56c4a5b3f16177767289544b0414e1ee2333ee15a04f3dd7b"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/envconsul/0.13.2/envconsul_0.13.2_darwin_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/envconsul/0.13.2/envconsul_0.13.2_darwin_arm64.zip"
     sha256 "a323e17c2d69e38f1c3da7e8c3a0c0d4da3492d20a40fdcdb719556264fc2962"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/envconsul/0.13.2/envconsul_0.13.2_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/envconsul/0.13.2/envconsul_0.13.2_linux_amd64.zip"
     sha256 "3a2719ad53e6b180f2accc9cd1b165fdca38a2e11e72504229a1aaaac9e7bd00"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/envconsul/0.13.2/envconsul_0.13.2_linux_arm.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/envconsul/0.13.2/envconsul_0.13.2_linux_arm.zip"
     sha256 "e98e41a87f409e1a9618872e72ef4bf5d1c03f8517f17baa7745f92d7c7d4305"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/envconsul/0.13.2/envconsul_0.13.2_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/envconsul/0.13.2/envconsul_0.13.2_linux_arm64.zip"
     sha256 "a413d7c6cae56de2b0b7215a64e74ee718a76ad2f9205ce95871340b5d7dfbd9"
   end
 

--- a/Formula/hc-install.rb
+++ b/Formula/hc-install.rb
@@ -7,27 +7,27 @@ class HcInstall < Formula
   version "0.7.0"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/hc-install/0.7.0/hc-install_0.7.0_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/hc-install/0.7.0/hc-install_0.7.0_darwin_amd64.zip"
     sha256 "eed428b46370cac7afb5088776eb2fc623eebd987601a61264e5fe591c6e91af"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/hc-install/0.7.0/hc-install_0.7.0_darwin_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/hc-install/0.7.0/hc-install_0.7.0_darwin_arm64.zip"
     sha256 "0096f0cebbf3c3367401bdd82708a5ee296c728a953011467ca01ca7a9ba875b"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/hc-install/0.7.0/hc-install_0.7.0_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/hc-install/0.7.0/hc-install_0.7.0_linux_amd64.zip"
     sha256 "ddd6ef412fd60fa2465b03e18292c9e1d4f148c8037058a08dd96ee889ce243d"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/hc-install/0.7.0/hc-install_0.7.0_linux_arm.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/hc-install/0.7.0/hc-install_0.7.0_linux_arm.zip"
     sha256 "f32b546f0cd9152ccfb4d0024c8af7b75cbb6b6d31e473d382e5f87056bef829"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/hc-install/0.7.0/hc-install_0.7.0_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/hc-install/0.7.0/hc-install_0.7.0_linux_arm64.zip"
     sha256 "1ab92ffb8b1fc389c8aaaa530aa86fb95e2d17a1b7d1d83a94ac6fb01a5bf759"
   end
 

--- a/Formula/hcdiag.rb
+++ b/Formula/hcdiag.rb
@@ -7,27 +7,27 @@ class Hcdiag < Formula
   version "0.5.3"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/hcdiag/0.5.3/hcdiag_0.5.3_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/hcdiag/0.5.3/hcdiag_0.5.3_darwin_amd64.zip"
     sha256 "2e0ba85d2425881c0a0481689bab09438d0fa05c14d5982975a2a443129414d5"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/hcdiag/0.5.3/hcdiag_0.5.3_darwin_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/hcdiag/0.5.3/hcdiag_0.5.3_darwin_arm64.zip"
     sha256 "c22634ac3236fa5beb99ef83bc802369d78c281f7403bdc351ad4ad0aadaa445"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/hcdiag/0.5.3/hcdiag_0.5.3_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/hcdiag/0.5.3/hcdiag_0.5.3_linux_amd64.zip"
     sha256 "e8b7e1cf7cd3216f0179a0d5fb44cb0d6b5425b7fd023849d2078f0f27d7cb63"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/hcdiag/0.5.3/hcdiag_0.5.3_linux_arm.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/hcdiag/0.5.3/hcdiag_0.5.3_linux_arm.zip"
     sha256 "233b94d5d0426eac582b91838eec70a9ccdd5333be1d214a177acffe5d9fb210"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/hcdiag/0.5.3/hcdiag_0.5.3_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/hcdiag/0.5.3/hcdiag_0.5.3_linux_arm64.zip"
     sha256 "0f6c53142fbc9d6d4748f16571df8e6903a4dc1373c20c9256f8c3424e0cdc54"
   end
 

--- a/Formula/hcp.rb
+++ b/Formula/hcp.rb
@@ -7,27 +7,27 @@ class Hcp < Formula
   version "0.4.0"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/hcp/0.4.0/hcp_0.4.0_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/hcp/0.4.0/hcp_0.4.0_darwin_amd64.zip"
     sha256 "8cc36144872e513ec1a564c2086307af511c55f59e6aa735ab2e3e6db4760d88"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/hcp/0.4.0/hcp_0.4.0_darwin_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/hcp/0.4.0/hcp_0.4.0_darwin_arm64.zip"
     sha256 "256ae425f8a8efde5636725ac2a3e59082b79af955419a8fb5795ac8b66b571c"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/hcp/0.4.0/hcp_0.4.0_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/hcp/0.4.0/hcp_0.4.0_linux_amd64.zip"
     sha256 "f60ed93b57d73d3d5fa26df59b09dc3b16f9b4ee2eadfef6b5ab216b62913352"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/hcp/0.4.0/hcp_0.4.0_linux_arm.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/hcp/0.4.0/hcp_0.4.0_linux_arm.zip"
     sha256 "76d1ca62821751c08e511bd8a48277cc74d0584bccf51be2fee59ac1e6fef3ec"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/hcp/0.4.0/hcp_0.4.0_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/hcp/0.4.0/hcp_0.4.0_linux_arm64.zip"
     sha256 "2c1c08802be382f5965a6c8cd875db2cdf0ffadd3f433cfffb45d5ee8664d801"
   end
 

--- a/Formula/levant.rb
+++ b/Formula/levant.rb
@@ -7,22 +7,22 @@ class Levant < Formula
   version "0.3.3"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/levant/0.3.3/levant_0.3.3_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/levant/0.3.3/levant_0.3.3_darwin_amd64.zip"
     sha256 "da1f7b45a5a10f8d2387ac40aac7eb52c3dbe6606e9948b51ee0efb82f88c165"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/levant/0.3.3/levant_0.3.3_darwin_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/levant/0.3.3/levant_0.3.3_darwin_arm64.zip"
     sha256 "aeb4e4a5bca4be48ba8706d671d50893f2db439cf61f302162293a4362bddeb0"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/levant/0.3.3/levant_0.3.3_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/levant/0.3.3/levant_0.3.3_linux_amd64.zip"
     sha256 "630c4c0499fdc0b904be22905e18dcd81350f8011ab1494b23f20d06f192d462"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/levant/0.3.3/levant_0.3.3_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/levant/0.3.3/levant_0.3.3_linux_arm64.zip"
     sha256 "e2e3bf5aed271d848d8aac86b4649594b7f9aa1e11aa4612f5b571f97598bba4"
   end
 

--- a/Formula/nomad-enterprise.rb
+++ b/Formula/nomad-enterprise.rb
@@ -7,22 +7,22 @@ class NomadEnterprise < Formula
   version "1.8.1+ent"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/nomad/1.8.1+ent/nomad_1.8.1+ent_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/nomad/1.8.1+ent/nomad_1.8.1+ent_darwin_amd64.zip"
     sha256 "f1ba069c75f35bb124a0be7dd0c895db43f1eb65012abcf4400b9c0a76583f51"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/nomad/1.8.1+ent/nomad_1.8.1+ent_darwin_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/nomad/1.8.1+ent/nomad_1.8.1+ent_darwin_arm64.zip"
     sha256 "8ce9d18ac40c73cb961a8f9c8afb1fffd0b29d5b07ee2b085585f3c003d2666e"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/nomad/1.8.1+ent/nomad_1.8.1+ent_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/nomad/1.8.1+ent/nomad_1.8.1+ent_linux_amd64.zip"
     sha256 "97e36863ece7cc86b6f5f9e3102de7fd9009ec17ff674a3af43290f0a466ed37"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/nomad/1.8.1+ent/nomad_1.8.1+ent_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/nomad/1.8.1+ent/nomad_1.8.1+ent_linux_arm64.zip"
     sha256 "d68cf392946b58dfddb72549db2c22306a8a8ac48f0f9cc4be90acf9a859ab06"
   end
 

--- a/Formula/nomad-pack.rb
+++ b/Formula/nomad-pack.rb
@@ -7,22 +7,22 @@ class NomadPack < Formula
   version "0.1.2"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/nomad-pack/0.1.2/nomad-pack_0.1.2_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/nomad-pack/0.1.2/nomad-pack_0.1.2_darwin_amd64.zip"
     sha256 "98ce44bf0a35a3d0148c766bdfd3fa330f9da00bcb2269b065ba55ed7d20eed8"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/nomad-pack/0.1.2/nomad-pack_0.1.2_darwin_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/nomad-pack/0.1.2/nomad-pack_0.1.2_darwin_arm64.zip"
     sha256 "12fb5cce35cc532513bb392a35c9c3af7a7381f232077c49b12510ba802dc82b"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/nomad-pack/0.1.2/nomad-pack_0.1.2_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/nomad-pack/0.1.2/nomad-pack_0.1.2_linux_amd64.zip"
     sha256 "7b89d9652e8622a99270fbbbc7fb457383d9f624faceaa41d2292bacd37a51ae"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/nomad-pack/0.1.2/nomad-pack_0.1.2_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/nomad-pack/0.1.2/nomad-pack_0.1.2_linux_arm64.zip"
     sha256 "bb1410a1efc80299792fd929e49d915e4db3a4a560a5de1c45e4628ff1f1e5fa"
   end
 

--- a/Formula/nomad.rb
+++ b/Formula/nomad.rb
@@ -7,22 +7,22 @@ class Nomad < Formula
   version "1.8.1"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/nomad/1.8.1/nomad_1.8.1_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/nomad/1.8.1/nomad_1.8.1_darwin_amd64.zip"
     sha256 "470d9b857de1ceb6feb20905f8fb812cff09292a296ef13140e2001580d3fbea"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/nomad/1.8.1/nomad_1.8.1_darwin_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/nomad/1.8.1/nomad_1.8.1_darwin_arm64.zip"
     sha256 "f88ab343bb308bf7aed9e5868de8e5298043d2f0e46031143ee1e5ba1de1043e"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/nomad/1.8.1/nomad_1.8.1_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/nomad/1.8.1/nomad_1.8.1_linux_amd64.zip"
     sha256 "29f91e539562bd377b9ecb82dd928526e24d0ef2b11537960fbbbb200713dc36"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/nomad/1.8.1/nomad_1.8.1_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/nomad/1.8.1/nomad_1.8.1_linux_arm64.zip"
     sha256 "b3cd3cb6dcfb4b022272d8c0a594f0d0aacb0ede9855ef2a5a707c4fcfe1715c"
   end
 

--- a/Formula/packer.rb
+++ b/Formula/packer.rb
@@ -7,27 +7,27 @@ class Packer < Formula
   version "1.11.0"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/packer/1.11.0/packer_1.11.0_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/packer/1.11.0/packer_1.11.0_darwin_amd64.zip"
     sha256 "7f2a9bcaf339864da0458f676d8b6581a2c274929327fb15a9a7d24e8ea8dcf5"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/packer/1.11.0/packer_1.11.0_darwin_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/packer/1.11.0/packer_1.11.0_darwin_arm64.zip"
     sha256 "d4933bbd36fa63ff904ba94fb02630a2489491eedf01af79c4cfb674bf989476"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/packer/1.11.0/packer_1.11.0_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/packer/1.11.0/packer_1.11.0_linux_amd64.zip"
     sha256 "dcac06a4c671bbb71e916da5abe947ebf4d6aa35c197e21c7c7b1d68cb8b7cad"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/packer/1.11.0/packer_1.11.0_linux_arm.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/packer/1.11.0/packer_1.11.0_linux_arm.zip"
     sha256 "644ff27386993ef09b29169c383b70c0c92aef6bce53bdd9f87b945c4a6a31bb"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/packer/1.11.0/packer_1.11.0_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/packer/1.11.0/packer_1.11.0_linux_arm64.zip"
     sha256 "0edd69e9cf34687d118610ed5de88fc18a2d3e2d9d3600ff3e76eaac08afd5cb"
   end
 

--- a/Formula/sentinel.rb
+++ b/Formula/sentinel.rb
@@ -7,27 +7,27 @@ class Sentinel < Formula
   version "0.26.2"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/sentinel/0.26.2/sentinel_0.26.2_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/sentinel/0.26.2/sentinel_0.26.2_darwin_amd64.zip"
     sha256 "ac93f0f656d676ad5315bb10bd322834e4c6e35ec2b181faeb3a69abd3afde97"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/sentinel/0.26.2/sentinel_0.26.2_darwin_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/sentinel/0.26.2/sentinel_0.26.2_darwin_arm64.zip"
     sha256 "5492f9b07aec1a46d077da4b3c9240b0d0203e9c3a691aba5525698d57f066fd"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/sentinel/0.26.2/sentinel_0.26.2_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/sentinel/0.26.2/sentinel_0.26.2_linux_amd64.zip"
     sha256 "2079f261b7e0c330c1150006243a7bc320b4fd50377c8136e44341cd0a89462b"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/sentinel/0.26.2/sentinel_0.26.2_linux_arm.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/sentinel/0.26.2/sentinel_0.26.2_linux_arm.zip"
     sha256 "12bd7d047950b6523543a93be3457a367699893cdcf3edb9bd22ec2e421b8a71"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/sentinel/0.26.2/sentinel_0.26.2_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/sentinel/0.26.2/sentinel_0.26.2_linux_arm64.zip"
     sha256 "7c346ac370a7cefe53eb314a18312435f34483811be9afec65af31e0a033c7e2"
   end
 

--- a/Formula/terraform-ls.rb
+++ b/Formula/terraform-ls.rb
@@ -7,27 +7,27 @@ class TerraformLs < Formula
   version "0.33.2"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/terraform-ls/0.33.2/terraform-ls_0.33.2_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/terraform-ls/0.33.2/terraform-ls_0.33.2_darwin_amd64.zip"
     sha256 "8de51bdc4cca248c100addaefd5b379566fecd1d991d18c42237c8b7bd69feed"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/terraform-ls/0.33.2/terraform-ls_0.33.2_darwin_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/terraform-ls/0.33.2/terraform-ls_0.33.2_darwin_arm64.zip"
     sha256 "a0174e9eb863bc6bd688b52a7de43faf72cc8addc5b304b356d2132fe2b07b76"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/terraform-ls/0.33.2/terraform-ls_0.33.2_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/terraform-ls/0.33.2/terraform-ls_0.33.2_linux_amd64.zip"
     sha256 "941a8de352951011dfbc816f7d48f68fb3908726147cf95389d0601223cbd832"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/terraform-ls/0.33.2/terraform-ls_0.33.2_linux_arm.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/terraform-ls/0.33.2/terraform-ls_0.33.2_linux_arm.zip"
     sha256 "0f47f0cbc81ca4952091a9786c8d2e37150f28499370e0362dc4db0ed6c85e94"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/terraform-ls/0.33.2/terraform-ls_0.33.2_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/terraform-ls/0.33.2/terraform-ls_0.33.2_linux_arm64.zip"
     sha256 "fb2ad60402062b2c8f639a35138b4f629896394a233c8924c04425e182980cd7"
   end
 

--- a/Formula/terraform.rb
+++ b/Formula/terraform.rb
@@ -7,27 +7,27 @@ class Terraform < Formula
   version "1.9.0"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/terraform/1.9.0/terraform_1.9.0_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/terraform/1.9.0/terraform_1.9.0_darwin_amd64.zip"
     sha256 "b69196c831d6315b6e79178c96a66365d724cf4b922ad4a9763cd970aeeecd45"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/terraform/1.9.0/terraform_1.9.0_darwin_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/terraform/1.9.0/terraform_1.9.0_darwin_arm64.zip"
     sha256 "b7701c42a9b69524cfe79f0928d48ec4d648bc5e08794df12e8b41b56a0a395c"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/terraform/1.9.0/terraform_1.9.0_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/terraform/1.9.0/terraform_1.9.0_linux_amd64.zip"
     sha256 "ab1358e73a81096bbe04201ef403a32e0765c5f6e360692d170d32d0889a4871"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/terraform/1.9.0/terraform_1.9.0_linux_arm.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/terraform/1.9.0/terraform_1.9.0_linux_arm.zip"
     sha256 "94d3fb0bd6df8de2cfb24781344036a15e9de8ee148b3cf1bc870c9ea69c88d8"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/terraform/1.9.0/terraform_1.9.0_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/terraform/1.9.0/terraform_1.9.0_linux_arm64.zip"
     sha256 "f5c0a49b482c008a6afd2248c08ca919e599c1154a850ff94809f4a85c86eb3b"
   end
 

--- a/Formula/tfstacks.rb
+++ b/Formula/tfstacks.rb
@@ -7,27 +7,27 @@ class Tfstacks < Formula
   version "0.3.0"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/tfstacks/0.3.0/tfstacks_0.3.0_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/tfstacks/0.3.0/tfstacks_0.3.0_darwin_amd64.zip"
     sha256 "6297ebd21eae0039ed60c3cb50293adcca15a6e797d4c92da6829a0b426abe83"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/tfstacks/0.3.0/tfstacks_0.3.0_darwin_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/tfstacks/0.3.0/tfstacks_0.3.0_darwin_arm64.zip"
     sha256 "b29e66821a9fa28ea0628ca84889dcc8c322bc9b6d38f0e89434c232f4207b40"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/tfstacks/0.3.0/tfstacks_0.3.0_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/tfstacks/0.3.0/tfstacks_0.3.0_linux_amd64.zip"
     sha256 "c403598a931b8392645e65c8772ec3271db4bac7ffa7fab43449c5e0cbf4faf2"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/tfstacks/0.3.0/tfstacks_0.3.0_linux_arm.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/tfstacks/0.3.0/tfstacks_0.3.0_linux_arm.zip"
     sha256 "23b6a7797782e2920daa44b9f4eaf3354f883eab67d602e650b937eb27c3dd1a"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/tfstacks/0.3.0/tfstacks_0.3.0_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/tfstacks/0.3.0/tfstacks_0.3.0_linux_arm64.zip"
     sha256 "842234946a20a25c5d930770366d60e929476b403a7e20034bc6e368a2c9ca5f"
   end
 

--- a/Formula/vagrant.rb
+++ b/Formula/vagrant.rb
@@ -7,7 +7,7 @@ class Vagrant < Formula
   version "2.4.1"
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/vagrant/2.4.1/vagrant_2.4.1_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/vagrant/2.4.1/vagrant_2.4.1_linux_amd64.zip"
     sha256 "73a3dacf3f36fb4af8ef514aeff245833d086430614f0c183be7e263553dd7c2"
   end
 

--- a/Formula/vault-enterprise.rb
+++ b/Formula/vault-enterprise.rb
@@ -7,27 +7,27 @@ class VaultEnterprise < Formula
   version "1.17.1+ent"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/vault/1.17.1+ent/vault_1.17.1+ent_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/vault/1.17.1+ent/vault_1.17.1+ent_darwin_amd64.zip"
     sha256 "03cc90e42284c331df50a4314293af28e175f9f8981cbaa1a53cdb76863d2acc"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/vault/1.17.1+ent/vault_1.17.1+ent_darwin_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/vault/1.17.1+ent/vault_1.17.1+ent_darwin_arm64.zip"
     sha256 "91db32d949c006863b1a7267ab3774ec33fa27f8a73a5835d571b2fa9f4a4bd9"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/vault/1.17.1+ent/vault_1.17.1+ent_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/vault/1.17.1+ent/vault_1.17.1+ent_linux_amd64.zip"
     sha256 "66051a3d5396c11cf954b47bd29da89491f63eafa143a15dcb54ba3d5bf66f80"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/vault/1.17.1+ent/vault_1.17.1+ent_linux_arm.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/vault/1.17.1+ent/vault_1.17.1+ent_linux_arm.zip"
     sha256 "46291d4bac3401ee7696f96bc2e0e02c82f18ad5b5a88bf15d475fed97af99ad"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/vault/1.17.1+ent/vault_1.17.1+ent_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/vault/1.17.1+ent/vault_1.17.1+ent_linux_arm64.zip"
     sha256 "5ce18a435d6c88e8bfe04b40dbbf46636dda0e1f26fe22f8dc26af1e976302bd"
   end
 

--- a/Formula/vault-radar.rb
+++ b/Formula/vault-radar.rb
@@ -7,22 +7,22 @@ class VaultRadar < Formula
   version "0.10.0"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/vault-radar/0.10.0/vault-radar_0.10.0_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/vault-radar/0.10.0/vault-radar_0.10.0_darwin_amd64.zip"
     sha256 "5b1fe7dfd0cd76597ae630f28908cdb74228bd31f5662780ae3337a8a0b5661e"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/vault-radar/0.10.0/vault-radar_0.10.0_darwin_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/vault-radar/0.10.0/vault-radar_0.10.0_darwin_arm64.zip"
     sha256 "3d78c15eacd599c57e1be1bb73e832df81835249970987d4f1b57ebd9b028698"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/vault-radar/0.10.0/vault-radar_0.10.0_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/vault-radar/0.10.0/vault-radar_0.10.0_linux_amd64.zip"
     sha256 "262642aac1a814de1d0422d0e539da13a42ff0209c2ac582b1cc3733e400b82c"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/vault-radar/0.10.0/vault-radar_0.10.0_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/vault-radar/0.10.0/vault-radar_0.10.0_linux_arm64.zip"
     sha256 "462747b8376814f98dff2bc89dc87553d4bd014e6663da7add882e75af2b2026"
   end
 

--- a/Formula/vault.rb
+++ b/Formula/vault.rb
@@ -7,27 +7,27 @@ class Vault < Formula
   version "1.17.1"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/vault/1.17.1/vault_1.17.1_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/vault/1.17.1/vault_1.17.1_darwin_amd64.zip"
     sha256 "043dfdf4fa51f2b8d7682dce00f6361a66b1d9d7e0e13c56f07328c8a901d22c"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/vault/1.17.1/vault_1.17.1_darwin_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/vault/1.17.1/vault_1.17.1_darwin_arm64.zip"
     sha256 "782eff3fddaf1a12a6467f899a81c1423a752c4c7d5f512232cbc3811fa07c54"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/vault/1.17.1/vault_1.17.1_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/vault/1.17.1/vault_1.17.1_linux_amd64.zip"
     sha256 "f2266dcecabff8809a54f7cf3688c1946408e8f863bcf379ef9146ab3a1c3f4a"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/vault/1.17.1/vault_1.17.1_linux_arm.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/vault/1.17.1/vault_1.17.1_linux_arm.zip"
     sha256 "c68cf3e54c964e6e7659c64a533a4d5d2702b4ed800ae941186c1c9f8a70323b"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/vault/1.17.1/vault_1.17.1_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/vault/1.17.1/vault_1.17.1_linux_arm64.zip"
     sha256 "6f6449cb8d353af99c8506f92b9b53111def3daba32c72f2483a8ae98faff2f2"
   end
 

--- a/Formula/vlt.rb
+++ b/Formula/vlt.rb
@@ -7,27 +7,27 @@ class Vlt < Formula
   version "1.0.0"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/vlt/1.0.0/vlt_1.0.0_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/vlt/1.0.0/vlt_1.0.0_darwin_amd64.zip"
     sha256 "47b0c99cc88fd5e8e0de60f283f86d0f5d9ba46dd10bb4a6c3c6e29eefdfe1db"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/vlt/1.0.0/vlt_1.0.0_darwin_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/vlt/1.0.0/vlt_1.0.0_darwin_arm64.zip"
     sha256 "c6e090f1d93c9977b039281d247aa66d91737ea0767547b20776635aa9eeaa69"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/vlt/1.0.0/vlt_1.0.0_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/vlt/1.0.0/vlt_1.0.0_linux_amd64.zip"
     sha256 "1a7ab59cb16446f39412d85cab24ec729986ca6ac0f7a49d0ae210e279024bf2"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/vlt/1.0.0/vlt_1.0.0_linux_arm.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/vlt/1.0.0/vlt_1.0.0_linux_arm.zip"
     sha256 "654f987b50f55654daf05d0f644a85ab625bf66282b7b9e9aa883e88b56ef9fd"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/vlt/1.0.0/vlt_1.0.0_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/vlt/1.0.0/vlt_1.0.0_linux_arm64.zip"
     sha256 "e20529046b9a24fac9bc5d271c13db745d181c55ceed285f8d36af61a562143e"
   end
 

--- a/Formula/waypoint.rb
+++ b/Formula/waypoint.rb
@@ -7,27 +7,27 @@ class Waypoint < Formula
   version "0.11.4"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/waypoint/0.11.4/waypoint_0.11.4_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/waypoint/0.11.4/waypoint_0.11.4_darwin_amd64.zip"
     sha256 "8942a7d00aaf0b39cec05e2f7da8788a2be0f2be0084236d228d031c6e56521f"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/waypoint/0.11.4/waypoint_0.11.4_darwin_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/waypoint/0.11.4/waypoint_0.11.4_darwin_arm64.zip"
     sha256 "c23da6fe2ba4db6f63963ef2e72caa71faae70b4f598d439d6f35d6abb79f557"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/waypoint/0.11.4/waypoint_0.11.4_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/waypoint/0.11.4/waypoint_0.11.4_linux_amd64.zip"
     sha256 "96d314f1bc182a30ca9e93910981fbd4ecf7290763c55d2d4e8ddce2b23abdca"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/waypoint/0.11.4/waypoint_0.11.4_linux_arm.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/waypoint/0.11.4/waypoint_0.11.4_linux_arm.zip"
     sha256 "81f9cb034cd8107dc5972130e379559c384249fe068a00653fc11c3bbb98ca31"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/waypoint/0.11.4/waypoint_0.11.4_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/waypoint/0.11.4/waypoint_0.11.4_linux_arm64.zip"
     sha256 "bbf331be8785a99a0bfcb4707a013355ba58516d0e9b1b78fd8808e4d2213e66"
   end
 

--- a/util/formula_templater/templates/cask.tmpl
+++ b/util/formula_templater/templates/cask.tmpl
@@ -7,19 +7,19 @@ cask "hashicorp-{{ .Product }}" do
   arch arm: "arm64", intel: "amd64"
   sha256 arm: "{{ .Architectures.DarwinArm64SHA }}",
          intel: "{{ .Architectures.DarwinAmd64SHA }}"
-  url "https://releases.hashicorp.com/{{ .Product }}/#{version}/{{ .Product }}_#{version}_darwin_#{arch}.dmg",
+  url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/{{ .Product }}/#{version}/{{ .Product }}_#{version}_darwin_#{arch}.dmg",
       verified: "hashicorp.com/{{ .Product }}/"
   {{- else }}
   {{- if .Architectures.DarwinAmd64SHA }}
   sha256 "{{ .Architectures.DarwinAmd64SHA }}"
 
-  url "https://releases.hashicorp.com/{{ .Product }}/#{version}/{{ .Product }}_#{version}_darwin_amd64.dmg",
+  url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/{{ .Product }}/#{version}/{{ .Product }}_#{version}_darwin_amd64.dmg",
       verified: "hashicorp.com/{{ .Product }}/"
   {{- end }}
   {{- if .Architectures.DarwinArm64SHA }}
   sha256 "{{ .Architectures.DarwinArm64SHA }}"
 
-  url "https://releases.hashicorp.com/{{ .Product }}/#{version}/{{ .Product }}_#{version}_darwin_arm64.dmg",
+  url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/{{ .Product }}/#{version}/{{ .Product }}_#{version}_darwin_arm64.dmg",
       verified: "hashicorp.com/{{ .Product }}/"
   {{- end }}
   {{- end }}

--- a/util/formula_templater/templates/formula.tmpl
+++ b/util/formula_templater/templates/formula.tmpl
@@ -10,18 +10,18 @@ class {{ .Name }} < Formula
   {{- if and .Architectures.DarwinAmd64 .Architectures.DarwinArm64 }}
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/{{ .Product }}/{{ .Version }}/{{ .Product }}_{{ .Version }}_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/{{ .Product }}/{{ .Version }}/{{ .Product }}_{{ .Version }}_darwin_amd64.zip"
     sha256 "{{ .Architectures.DarwinAmd64SHA }}"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/{{ .Product }}/{{ .Version }}/{{ .Product }}_{{ .Version }}_darwin_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/{{ .Product }}/{{ .Version }}/{{ .Product }}_{{ .Version }}_darwin_arm64.zip"
     sha256 "{{ .Architectures.DarwinArm64SHA }}"
   end
   {{- else }}
 
   if OS.mac?
-    url "https://releases.hashicorp.com/{{ .Product }}/{{ .Version }}/{{ .Product }}_{{ .Version }}_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/{{ .Product }}/{{ .Version }}/{{ .Product }}_{{ .Version }}_darwin_amd64.zip"
     sha256 "{{ .Architectures.DarwinAmd64SHA }}"
   end
 
@@ -40,21 +40,21 @@ class {{ .Name }} < Formula
   {{- if .Architectures.LinuxAmd64 }}
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/{{ .Product }}/{{ .Version }}/{{ .Product }}_{{ .Version }}_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/{{ .Product }}/{{ .Version }}/{{ .Product }}_{{ .Version }}_linux_amd64.zip"
     sha256 "{{ .Architectures.LinuxAmd64SHA }}"
   end
   {{- end }}
   {{- if .Architectures.LinuxArm }}
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/{{ .Product }}/{{ .Version }}/{{ .Product }}_{{ .Version }}_linux_arm.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/{{ .Product }}/{{ .Version }}/{{ .Product }}_{{ .Version }}_linux_arm.zip"
     sha256 "{{ .Architectures.LinuxArmSHA }}"
   end
   {{- end }}
   {{- if .Architectures.LinuxArm64 }}
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/{{ .Product }}/{{ .Version }}/{{ .Product }}_{{ .Version }}_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/{{ .Product }}/{{ .Version }}/{{ .Product }}_{{ .Version }}_linux_arm64.zip"
     sha256 "{{ .Architectures.LinuxArm64SHA }}"
   end
 

--- a/util/formula_templater/testdata/boundary-desktop-cask.rb
+++ b/util/formula_templater/testdata/boundary-desktop-cask.rb
@@ -5,7 +5,7 @@ cask "hashicorp-boundary-desktop" do
   version "1.6.0"
   sha256 "b6b5b15dfb469b7fdab9216788f5931e96561104de1ff7f9e0d6fda54701be09"
 
-  url "https://releases.hashicorp.com/boundary-desktop/#{version}/boundary-desktop_#{version}_darwin_amd64.dmg",
+  url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/boundary-desktop/#{version}/boundary-desktop_#{version}_darwin_amd64.dmg",
       verified: "hashicorp.com/boundary-desktop/"
   name "Boundary Desktop"
   desc ""

--- a/util/formula_templater/testdata/consul-enterprise.rb
+++ b/util/formula_templater/testdata/consul-enterprise.rb
@@ -7,27 +7,27 @@ class ConsulEnterprise < Formula
   version "1.15.1+ent"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul/1.15.1+ent/consul_1.15.1+ent_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul/1.15.1+ent/consul_1.15.1+ent_darwin_amd64.zip"
     sha256 "5a020a09b2dd7991f930596e751bdde51bba35b854912411e552782d4181618d"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/consul/1.15.1+ent/consul_1.15.1+ent_darwin_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul/1.15.1+ent/consul_1.15.1+ent_darwin_arm64.zip"
     sha256 "262bab1c8776f97cc74ae02bb347bcc223bfdc44f83dc9190ea098b451d3ee65"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul/1.15.1+ent/consul_1.15.1+ent_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul/1.15.1+ent/consul_1.15.1+ent_linux_amd64.zip"
     sha256 "5e5f8c4a55567c37187de35c802eef2f04e9184c5a7bad64a914256b14701422"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul/1.15.1+ent/consul_1.15.1+ent_linux_arm.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul/1.15.1+ent/consul_1.15.1+ent_linux_arm.zip"
     sha256 "7bc00fb0f373d9d71a8fa447602339033ad51bd2abbf1d084669adb2e6b76ac7"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul/1.15.1+ent/consul_1.15.1+ent_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul/1.15.1+ent/consul_1.15.1+ent_linux_arm64.zip"
     sha256 "e2594c265b08b00a33dfeb65221876b63a25d34e5d4d8cb1c8e33d54d71ab503"
   end
 

--- a/util/formula_templater/testdata/consul.rb
+++ b/util/formula_templater/testdata/consul.rb
@@ -7,27 +7,27 @@ class Consul < Formula
   version "1.15.1"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul/1.15.1/consul_1.15.1_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul/1.15.1/consul_1.15.1_darwin_amd64.zip"
     sha256 "311c593dc9be13475a42bd97016f302dbf174f6232c4fcf81218c21a5cb879ea"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/consul/1.15.1/consul_1.15.1_darwin_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul/1.15.1/consul_1.15.1_darwin_arm64.zip"
     sha256 "e06fd7783008a8944a4824747f3e8c9d98864960072201cad615f26d42ce99e0"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/consul/1.15.1/consul_1.15.1_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul/1.15.1/consul_1.15.1_linux_amd64.zip"
     sha256 "23f7eb0461dd01a95c5d56472b91c22d5dacec84f31f1846c0c9f9621f98f29f"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul/1.15.1/consul_1.15.1_linux_arm.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul/1.15.1/consul_1.15.1_linux_arm.zip"
     sha256 "09c53fc66d46b132d5f7acb7d21758056602be9495c8a1d409ec8cef45328dd8"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/consul/1.15.1/consul_1.15.1_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/consul/1.15.1/consul_1.15.1_linux_arm64.zip"
     sha256 "4e5e42186ff9f7a3e9736f871a81ff3732f7e150664376e1bf290661544a4654"
   end
 

--- a/util/formula_templater/testdata/vagrant-cask.rb
+++ b/util/formula_templater/testdata/vagrant-cask.rb
@@ -6,7 +6,7 @@ cask "hashicorp-vagrant" do
   arch arm: "arm64", intel: "amd64"
   sha256 arm: "4daf4d4c323cce7bf98065ecf5338e9800038a522cd81356c77555d9cd2f0db9",
          intel: "4daf4d4c323cce7bf98065ecf5338e9800038a522cd81356c77555d9cd2f0db9"
-  url "https://releases.hashicorp.com/vagrant/#{version}/vagrant_#{version}_darwin_#{arch}.dmg",
+  url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/vagrant/#{version}/vagrant_#{version}_darwin_#{arch}.dmg",
       verified: "hashicorp.com/vagrant/"
   name "Vagrant"
   desc "Development environment"

--- a/util/formula_templater/testdata/vagrant-formula.rb
+++ b/util/formula_templater/testdata/vagrant-formula.rb
@@ -7,7 +7,7 @@ class Vagrant < Formula
   version "2.3.6"
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/vagrant/2.3.6/vagrant_2.3.6_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/vagrant/2.3.6/vagrant_2.3.6_linux_amd64.zip"
     sha256 "71a616220e0f68d4882573afed4263a362eaafd14833a4f7e7c26f0cc0490157"
   end
 

--- a/util/lambda_trigger/testdata/github.com_cask_boundary-desktop.rb
+++ b/util/lambda_trigger/testdata/github.com_cask_boundary-desktop.rb
@@ -2,7 +2,7 @@ cask "hashicorp-boundary-desktop" do
   version "1.5.0"
   sha256 "861a1c0c11b70d8c1897e9cc78ce323b1e0df88217461255b92f09088c9bd15f"
 
-  url "https://releases.hashicorp.com/boundary-desktop/#{version}/boundary-desktop_#{version}_darwin_amd64.dmg"
+  url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/boundary-desktop/#{version}/boundary-desktop_#{version}_darwin_amd64.dmg"
   name "Boundary Desktop"
   desc ""
   homepage "https://www.boundaryproject.io/"

--- a/util/lambda_trigger/testdata/github.com_formula_nomad-enterprise.rb
+++ b/util/lambda_trigger/testdata/github.com_formula_nomad-enterprise.rb
@@ -4,27 +4,27 @@ class NomadEnterprise < Formula
   version "1.3.5+ent"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/nomad/1.3.5+ent/nomad_1.3.5+ent_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/nomad/1.3.5+ent/nomad_1.3.5+ent_darwin_amd64.zip"
     sha256 "098a48d43a8b3f9d99483e050585790584e8480b9c36d862ef3ec25a04771fa4"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/nomad/1.3.5+ent/nomad_1.3.5+ent_darwin_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/nomad/1.3.5+ent/nomad_1.3.5+ent_darwin_arm64.zip"
     sha256 "a14fd62aed34e06f14421a99e19b668d80f7868af57c8b3f59dae4177e2a6300"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/nomad/1.3.5+ent/nomad_1.3.5+ent_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/nomad/1.3.5+ent/nomad_1.3.5+ent_linux_amd64.zip"
     sha256 "cd41ff13ff417a7a449ede4e5fbf02613c9e7f497f5657d866e926455fa88e9d"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/nomad/1.3.5+ent/nomad_1.3.5+ent_linux_arm.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/nomad/1.3.5+ent/nomad_1.3.5+ent_linux_arm.zip"
     sha256 "23be6d1f4902893e64e21b30d9d8c7f483a57f81f2377513ecc91eec541c6f9c"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/nomad/1.3.5+ent/nomad_1.3.5+ent_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/nomad/1.3.5+ent/nomad_1.3.5+ent_linux_arm64.zip"
     sha256 "c682566a208e78a780d6e0bf8518629e4d3cb3d7fcdf6d9657e76f1d577fda3b"
   end
 

--- a/util/lambda_trigger/testdata/github.com_formula_nomad.rb
+++ b/util/lambda_trigger/testdata/github.com_formula_nomad.rb
@@ -4,7 +4,7 @@ class Nomad < Formula
   version "1.3.5"
 
   if OS.mac?
-    url "https://releases.hashicorp.com/nomad/1.3.5/nomad_1.3.5_darwin_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/nomad/1.3.5/nomad_1.3.5_darwin_amd64.zip"
     sha256 "36322d32e0c6dc4c98681d9492422551105da89b648d1b29637accc6ed101105"
   end
 
@@ -20,17 +20,17 @@ class Nomad < Formula
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/nomad/1.3.5/nomad_1.3.5_linux_amd64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/nomad/1.3.5/nomad_1.3.5_linux_amd64.zip"
     sha256 "a4bf189e6a84c4bc7d6090529c87b32e6b4b09b47163514d33305aa867d7c4dc"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/nomad/1.3.5/nomad_1.3.5_linux_arm.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/nomad/1.3.5/nomad_1.3.5_linux_arm.zip"
     sha256 "d0958235c852b6a5751e4362c4d6fe4e11d32c0bd17335d0905e836309fb7d52"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/nomad/1.3.5/nomad_1.3.5_linux_arm64.zip"
+    url "#{ENV['HOMEBREW_TAP_HASHICORP_REMOTE'].presence || 'https://releases.hashicorp.com'}/nomad/1.3.5/nomad_1.3.5_linux_arm64.zip"
     sha256 "bf8e6f9ceaa24ba3e43af3afa09d05ed2b67e95cfdbd8ba7453396c63ffe6d4b"
   end
 


### PR DESCRIPTION
Closes #265 

Configuring the env var `HOMEBREW_TAP_HASHICORP_REMOTE` allows to download from custom remotes.

How do you like the idea?