### PR TITLE
Update codeowners for SMRE

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/publish-homebrew-lambda.yml
+++ b/.github/workflows/publish-homebrew-lambda.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Invoke homebrew lambda update workflow
-        uses: benc-uk/workflow-dispatch@v1
+        uses: benc-uk/workflow-dispatch@25b02cc069be46d637e8fe2f1e8484008e9e9609 # v1.2.3
         with:
           workflow: homebrew-lambda-update.yml
           repo: hashicorp/releng-support

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in
 # the repo, unless a later match takes precedence. 
 
-* @hashicorp/release-engineering
+@hashicorp/team-selfmanaged-releng

--- a/META.d/_summary.yaml
+++ b/META.d/_summary.yaml
@@ -1,8 +1,9 @@
 ---
 schema: 1.1
-category: service
+partition: release-engineering
+category: none
 summary:
-  owner: team-rel-eng
+  owner: team-selfmanaged-releng
   description: |
     Homebrew casks and taps for HashiCorp products.
   visibility: external

--- a/META.d/tags.yaml
+++ b/META.d/tags.yaml
@@ -1,4 +1,4 @@
 ---
-# excemption required by automation
+# exemption required by automation
 tags:
   exempt: github-default-branch-protection-rule

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Heimdall](https://heimdall.hashicorp.services/api/v1/assets/homebrew-tap/badge.svg?key=f0ea6d408d7a7798bcd4f6ef4a40fe9c791109ca85d2f20d5630a9f4abafa9f6)](https://heimdall.hashicorp.services/site/assets/homebrew-tap)
+
 # HashiCorp Homebrew Tap
 
 ## What is Homebrew?


### PR DESCRIPTION
Update CODEOWNERS for SMRE

This facilitates GH automatically selecting appropriate PR reviewers
and team discovery through Heimdall.

[skip ci]