### PR TITLE
No 32-bit Nomad and Nomad ecosystem builds

### DIFF
--- a/util/formula_templater/config.hcl
+++ b/util/formula_templater/config.hcl
@@ -221,7 +221,7 @@ formula {
         darwin_amd64 = true
         darwin_arm64 = true
         linux_amd64 = true
-        linux_arm = true
+        linux_arm = false
         linux_arm64 = true
     }
     service_args = ["agent", "-dev"]
@@ -236,7 +236,7 @@ formula {
         darwin_amd64 = true
         darwin_arm64 = true
         linux_amd64 = true
-        linux_arm = true
+        linux_arm = false
         linux_arm64 = true
     }
     service_args = ["agent", "-dev"]
@@ -380,7 +380,7 @@ formula {
         darwin_amd64 = true
         darwin_arm64 = true
         linux_amd64 = true
-        linux_arm = true
+        linux_arm = false
         linux_arm64 = true
     }
 }
@@ -394,7 +394,7 @@ formula {
         darwin_amd64 = true
         darwin_arm64 = false
         linux_amd64 = true
-        linux_arm = true
+        linux_arm = false
         linux_arm64 = true
     }
 }

--- a/util/formula_templater/config.hcl
+++ b/util/formula_templater/config.hcl
@@ -392,7 +392,7 @@ formula {
     homepage = "https://github.com/hashicorp/levant"
     architectures {
         darwin_amd64 = true
-        darwin_arm64 = false
+        darwin_arm64 = true
         linux_amd64 = true
         linux_arm = false
         linux_arm64 = true


### PR DESCRIPTION
Nomad will no longer be producing 32-bit builds of any of the ecosystem binaries. This removes them from the brew tap.

Ref: https://github.com/hashicorp/nomad-pack/pull/518
Ref: https://github.com/hashicorp/nomad/pull/23189
Ref: https://github.com/hashicorp/nomad-enterprise/issues/1053
Ref: https://github.com/hashicorp/levant/pull/541