### PR TITLE
Fix Name in tf-migrate to be valid Ruby Class name

### DIFF
--- a/util/formula_templater/config.hcl
+++ b/util/formula_templater/config.hcl
@@ -444,8 +444,8 @@ formula {
 
 formula {
     product = "tf-migrate"
-    name = "tf-migrate"
-    desc = "tf-migrate"
+    name = "TfMigrate"
+    desc = "Terraform Migrate"
     homepage = "https://www.terraform.io"
     architectures {
         darwin_amd64 = true


### PR DESCRIPTION
The name used currently is an invalid Ruby class name

This results in the following incorrect formula:

https://github.com/hashicorp/homebrew-tap/commit/f3d8e2ec380327287a9efabedc51a131c11ac0a6#diff-bbce9fac5595a26442059aeafb8bab526fae892f84379d558e87c6822cadea54R4