### PR TITLE
only run lambda publish when changing lambda code

### DIFF
--- a/.github/workflows/publish-homebrew-lambda.yml
+++ b/.github/workflows/publish-homebrew-lambda.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - master
+    paths:
+      - "util/lambda_trigger/**" # only publish lambda when changing lambda code
 jobs:
   example:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When changes are to any other code besides the lambda, we don't need to rebuild and publish it. 