### PR TITLE
Bump vagrant to 2.4.3

### DIFF
--- a/Casks/hashicorp-vagrant.rb
+++ b/Casks/hashicorp-vagrant.rb
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: MPL-2.0
 
 cask "hashicorp-vagrant" do
-  version "2.4.2"
+  version "2.4.3"
   arch arm: "arm64", intel: "amd64"
-  sha256 arm: "dec702353ed087d1e1a18a22c3af75d644eb8004ddbcb2cf337c0bfc471842d3",
-         intel: "dec702353ed087d1e1a18a22c3af75d644eb8004ddbcb2cf337c0bfc471842d3"
+  sha256 arm: "3cfe992d505271620da797cd1c43648dc9cf546c3d90f7c4d45f04741d29803f",
+         intel: "3cfe992d505271620da797cd1c43648dc9cf546c3d90f7c4d45f04741d29803f"
   url "https://releases.hashicorp.com/vagrant/#{version}/vagrant_#{version}_darwin_#{arch}.dmg",
       verified: "hashicorp.com/vagrant/"
   name "Vagrant"


### PR DESCRIPTION
2.4.3 has been out for a few months now, but still not available via brew.

Checksums taken from:
https://releases.hashicorp.com/vagrant/2.4.3/

Similar update to the previous one:
https://github.com/hashicorp/homebrew-tap/commit/6484f2f0fef0239f027f9b1cb451e19aa39e7ae5

Fixes https://github.com/hashicorp/homebrew-tap/issues/294