### PR TITLE
Fix Vagrant formula validation errors on unsupported platforms by enforcing Linux x86_64 requirement at formula level

### DIFF
--- a/Formula/vagrant.rb
+++ b/Formula/vagrant.rb
@@ -9,10 +9,10 @@ class Vagrant < Formula
   depends_on :linux
   depends_on arch: :x86_64
 
-  if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/vagrant/2.4.9/vagrant_2.4.9_linux_amd64.zip"
-    sha256 "77d4d533c82c420b6b594992a902ec43fcd9f50380dc002a599e93fc744f8cfa"
-  end
+  odie "Use hashicorp-vagrant cask on macOS" if OS.mac?
+
+  url "https://releases.hashicorp.com/vagrant/2.4.9/vagrant_2.4.9_linux_amd64.zip"
+  sha256 "77d4d533c82c420b6b594992a902ec43fcd9f50380dc002a599e93fc744f8cfa"
 
   conflicts_with "vagrant"
 

--- a/Formula/vagrant.rb
+++ b/Formula/vagrant.rb
@@ -6,6 +6,9 @@ class Vagrant < Formula
   homepage "https://www.vagrantup.com/"
   version "2.4.9"
 
+  depends_on :linux
+  depends_on arch: :x86_64
+
   if OS.linux? && Hardware::CPU.intel?
     url "https://releases.hashicorp.com/vagrant/2.4.9/vagrant_2.4.9_linux_amd64.zip"
     sha256 "77d4d533c82c420b6b594992a902ec43fcd9f50380dc002a599e93fc744f8cfa"

--- a/Formula/vagrant.rb
+++ b/Formula/vagrant.rb
@@ -9,8 +9,6 @@ class Vagrant < Formula
   depends_on :linux
   depends_on arch: :x86_64
 
-  odie "Use hashicorp-vagrant cask on macOS" if OS.mac?
-
   url "https://releases.hashicorp.com/vagrant/2.4.9/vagrant_2.4.9_linux_amd64.zip"
   sha256 "77d4d533c82c420b6b594992a902ec43fcd9f50380dc002a599e93fc744f8cfa"
 

--- a/util/formula_templater/testdata/vagrant-formula.rb
+++ b/util/formula_templater/testdata/vagrant-formula.rb
@@ -6,10 +6,11 @@ class Vagrant < Formula
   homepage "https://www.vagrantup.com/"
   version "2.3.6"
 
-  if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/vagrant/2.3.6/vagrant_2.3.6_linux_amd64.zip"
-    sha256 "71a616220e0f68d4882573afed4263a362eaafd14833a4f7e7c26f0cc0490157"
-  end
+  depends_on :linux
+  depends_on arch: :x86_64
+
+  url "https://releases.hashicorp.com/vagrant/2.3.6/vagrant_2.3.6_linux_amd64.zip"
+  sha256 "71a616220e0f68d4882573afed4263a362eaafd14833a4f7e7c26f0cc0490157"
 
   conflicts_with "vagrant"
 


### PR DESCRIPTION
## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

Fixes: 
- #305
- #267 
- #258 

The current Formula/vagrant.rb conditionally defines the url and sha256 only for:

Linux
x86_64 architecture

On unsupported platforms (e.g. macOS and Linux ARM64), the formula is still parsed by Homebrew but does not define a url, which causes Homebrew to fail during formula validation with:
formula requires at least a URL

This occurs before depends_on constraints are evaluated, meaning platform guards alone are insufficient to prevent parsing errors.

Homebrew requires all formulas to define a valid source url at parse time, regardless of platform constraints.
Conditional url definitions cause formula validation to fail before dependency checks are applied.
This change aligns the formula with Homebrew’s expected DSL semantics and prevents import-time failures on unsupported platforms.

**Impact:**
No change for Linux x86_64 users (primary supported platform)
macOS users no longer see formula parse/import errors
Unsupported architectures receive clear installation-time failure messages instead of tap parsing errors


```
brew install hashicorp/tap/vagrant
==> Fetching downloads for: vagrant
vagrant: Linux is required for this software.
vagrant: The x86_64 architecture is required for this software.
```

**Revert plan:**
This change can be reverted safely by restoring the original conditional url block in Formula/vagrant.rb.
No downstream state changes or migrations are introduced.

No security control changes are introduced by this modification.