### PR TITLE
fix: wrap macOS-only stanzas in on_macos for Linux tap validation

### DIFF
--- a/Casks/hashicorp-boundary-desktop.rb
+++ b/Casks/hashicorp-boundary-desktop.rb
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: MPL-2.0
 
 cask "hashicorp-boundary-desktop" do
-  version "2.6.0"
+  version "2.6.1"
 
   on_macos do
     arch arm: "arm64", intel: "amd64"
-    sha256 arm: "a292b940f04cec8e7770de1c691cb91df0169dc57e5c161740956d7fb7768235",
-           intel: "f5d236ef1c40784100485e4247de3d3ea325c6a2ebd664d7895cca2a469b7830"
+    sha256 arm: "636f4564d203f7d69de15c2655d167e4b7eef3455464ab14f4ba38f86e11edc2",
+           intel: "8773effd0457b337b8adca85608442be29991f362099c9d915758b6b2e4a741a"
     url "https://releases.hashicorp.com/boundary-desktop/#{version}/boundary-desktop_#{version}_darwin_#{arch}.dmg",
         verified: "hashicorp.com/boundary-desktop/"
 

--- a/Casks/hashicorp-boundary-desktop.rb
+++ b/Casks/hashicorp-boundary-desktop.rb
@@ -3,15 +3,19 @@
 
 cask "hashicorp-boundary-desktop" do
   version "2.6.0"
-  arch arm: "arm64", intel: "amd64"
-  sha256 arm: "a292b940f04cec8e7770de1c691cb91df0169dc57e5c161740956d7fb7768235",
-         intel: "f5d236ef1c40784100485e4247de3d3ea325c6a2ebd664d7895cca2a469b7830"
-  url "https://releases.hashicorp.com/boundary-desktop/#{version}/boundary-desktop_#{version}_darwin_#{arch}.dmg",
-      verified: "hashicorp.com/boundary-desktop/"
+
+  on_macos do
+    arch arm: "arm64", intel: "amd64"
+    sha256 arm: "a292b940f04cec8e7770de1c691cb91df0169dc57e5c161740956d7fb7768235",
+           intel: "f5d236ef1c40784100485e4247de3d3ea325c6a2ebd664d7895cca2a469b7830"
+    url "https://releases.hashicorp.com/boundary-desktop/#{version}/boundary-desktop_#{version}_darwin_#{arch}.dmg",
+        verified: "hashicorp.com/boundary-desktop/"
+
+    app "Boundary.app"
+  end
+
   name "Boundary Desktop"
   desc ""
   homepage "https://www.boundaryproject.io/"
-
-  app "Boundary.app"
 
 end

--- a/Casks/hashicorp-vagrant.rb
+++ b/Casks/hashicorp-vagrant.rb
@@ -3,11 +3,26 @@
 
 cask "hashicorp-vagrant" do
   version "2.4.9"
-  arch arm: "arm64", intel: "amd64"
-  sha256 arm: "8de08bd435ef8ae0fc5fbd6acefa9c68e62fb898c5ae0fbdacd26853bea9d4d6",
-         intel: "8de08bd435ef8ae0fc5fbd6acefa9c68e62fb898c5ae0fbdacd26853bea9d4d6"
-  url "https://releases.hashicorp.com/vagrant/#{version}/vagrant_#{version}_darwin_#{arch}.dmg",
-      verified: "hashicorp.com/vagrant/"
+
+  on_macos do
+    arch arm: "arm64", intel: "amd64"
+    sha256 arm: "8de08bd435ef8ae0fc5fbd6acefa9c68e62fb898c5ae0fbdacd26853bea9d4d6",
+           intel: "8de08bd435ef8ae0fc5fbd6acefa9c68e62fb898c5ae0fbdacd26853bea9d4d6"
+    url "https://releases.hashicorp.com/vagrant/#{version}/vagrant_#{version}_darwin_#{arch}.dmg",
+        verified: "hashicorp.com/vagrant/"
+
+    pkg "vagrant.pkg"
+
+    uninstall script: {
+      executable: "uninstall.tool",
+      input: ["Yes"],
+      sudo:  true,
+    },
+    pkgutil: "com.vagrant.vagrant"
+
+    zap trash: "~/.vagrant.d"
+  end
+
   name "Vagrant"
   desc "Development environment"
   homepage "https://www.vagrantup.com/"
@@ -16,16 +31,5 @@ cask "hashicorp-vagrant" do
     url "https://github.com/hashicorp/vagrant"
     strategy :git
   end
-
-  pkg "vagrant.pkg"
-
-  uninstall script: {
-    executable: "uninstall.tool",
-    input: ["Yes"],
-    sudo:  true,
-  },
-  pkgutil: "com.vagrant.vagrant"
-
-  zap trash: "~/.vagrant.d"
 
 end

--- a/util/formula_templater/formula.go
+++ b/util/formula_templater/formula.go
@@ -42,7 +42,6 @@ func printCask(product, version, configLocation string, out io.Writer) error {
 	}
 
 	t := template.Must(template.New("cask").Parse(caskTemplate))
-
 	return t.Execute(out, productConfig)
 }
 

--- a/util/formula_templater/templates/cask.tmpl
+++ b/util/formula_templater/templates/cask.tmpl
@@ -3,26 +3,50 @@
 
 cask "hashicorp-{{ .Product }}" do
   version "{{ .Version }}"
+
+  on_macos do
   {{- if and .Architectures.DarwinAmd64SHA .Architectures.DarwinArm64SHA }}
-  arch arm: "arm64", intel: "amd64"
-  sha256 arm: "{{ .Architectures.DarwinArm64SHA }}",
-         intel: "{{ .Architectures.DarwinAmd64SHA }}"
-  url "https://releases.hashicorp.com/{{ .Product }}/#{version}/{{ .Product }}_#{version}_darwin_#{arch}.dmg",
-      verified: "hashicorp.com/{{ .Product }}/"
+    arch arm: "arm64", intel: "amd64"
+    sha256 arm: "{{ .Architectures.DarwinArm64SHA }}",
+           intel: "{{ .Architectures.DarwinAmd64SHA }}"
+    url "https://releases.hashicorp.com/{{ .Product }}/#{version}/{{ .Product }}_#{version}_darwin_#{arch}.dmg",
+        verified: "hashicorp.com/{{ .Product }}/"
   {{- else }}
   {{- if .Architectures.DarwinAmd64SHA }}
-  sha256 "{{ .Architectures.DarwinAmd64SHA }}"
+    sha256 "{{ .Architectures.DarwinAmd64SHA }}"
 
-  url "https://releases.hashicorp.com/{{ .Product }}/#{version}/{{ .Product }}_#{version}_darwin_amd64.dmg",
-      verified: "hashicorp.com/{{ .Product }}/"
+    url "https://releases.hashicorp.com/{{ .Product }}/#{version}/{{ .Product }}_#{version}_darwin_amd64.dmg",
+        verified: "hashicorp.com/{{ .Product }}/"
   {{- end }}
   {{- if .Architectures.DarwinArm64SHA }}
-  sha256 "{{ .Architectures.DarwinArm64SHA }}"
+    sha256 "{{ .Architectures.DarwinArm64SHA }}"
 
-  url "https://releases.hashicorp.com/{{ .Product }}/#{version}/{{ .Product }}_#{version}_darwin_arm64.dmg",
-      verified: "hashicorp.com/{{ .Product }}/"
+    url "https://releases.hashicorp.com/{{ .Product }}/#{version}/{{ .Product }}_#{version}_darwin_arm64.dmg",
+        verified: "hashicorp.com/{{ .Product }}/"
   {{- end }}
   {{- end }}
+
+  {{- if .CaskApp }}
+
+    app "{{ .CaskApp }}"
+  {{- else }}
+
+    pkg "{{ .CaskPkg }}"
+  {{- end }}
+
+  {{- if eq .Product "vagrant" }}
+
+    uninstall script: {
+      executable: "uninstall.tool",
+      input: ["Yes"],
+      sudo:  true,
+    },
+    pkgutil: "com.{{ .Product}}.{{ .Product }}"
+
+    zap trash: "~/.{{ .Product }}.d"
+  {{- end}}
+  end
+
   name "{{ .Name }}"
   desc "{{ .Desc }}"
   homepage "{{ .Homepage }}"
@@ -34,25 +58,5 @@ cask "hashicorp-{{ .Product }}" do
     strategy :git
   end
   {{- end }}
-
-  {{- if .CaskApp }}
-
-  app "{{ .CaskApp }}"
-  {{- else }}
-
-  pkg "{{ .CaskPkg }}"
-  {{- end }}
-
-  {{- if eq .Product "vagrant" }}
-
-  uninstall script: {
-    executable: "uninstall.tool",
-    input: ["Yes"],
-    sudo:  true,
-  },
-  pkgutil: "com.{{ .Product}}.{{ .Product }}"
-
-  zap trash: "~/.{{ .Product }}.d"
-  {{- end}}
 
 end

--- a/util/formula_templater/testdata/boundary-desktop-cask.rb
+++ b/util/formula_templater/testdata/boundary-desktop-cask.rb
@@ -3,14 +3,18 @@
 
 cask "hashicorp-boundary-desktop" do
   version "1.6.0"
-  sha256 "b6b5b15dfb469b7fdab9216788f5931e96561104de1ff7f9e0d6fda54701be09"
 
-  url "https://releases.hashicorp.com/boundary-desktop/#{version}/boundary-desktop_#{version}_darwin_amd64.dmg",
-      verified: "hashicorp.com/boundary-desktop/"
+  on_macos do
+    sha256 "b6b5b15dfb469b7fdab9216788f5931e96561104de1ff7f9e0d6fda54701be09"
+
+    url "https://releases.hashicorp.com/boundary-desktop/#{version}/boundary-desktop_#{version}_darwin_amd64.dmg",
+        verified: "hashicorp.com/boundary-desktop/"
+
+    app "Boundary.app"
+  end
+
   name "Boundary Desktop"
   desc ""
   homepage "https://www.boundaryproject.io/"
-
-  app "Boundary.app"
 
 end

--- a/util/formula_templater/testdata/vagrant-cask.rb
+++ b/util/formula_templater/testdata/vagrant-cask.rb
@@ -3,11 +3,26 @@
 
 cask "hashicorp-vagrant" do
   version "2.3.6"
-  arch arm: "arm64", intel: "amd64"
-  sha256 arm: "4daf4d4c323cce7bf98065ecf5338e9800038a522cd81356c77555d9cd2f0db9",
-         intel: "4daf4d4c323cce7bf98065ecf5338e9800038a522cd81356c77555d9cd2f0db9"
-  url "https://releases.hashicorp.com/vagrant/#{version}/vagrant_#{version}_darwin_#{arch}.dmg",
-      verified: "hashicorp.com/vagrant/"
+
+  on_macos do
+    arch arm: "arm64", intel: "amd64"
+    sha256 arm: "4daf4d4c323cce7bf98065ecf5338e9800038a522cd81356c77555d9cd2f0db9",
+           intel: "4daf4d4c323cce7bf98065ecf5338e9800038a522cd81356c77555d9cd2f0db9"
+    url "https://releases.hashicorp.com/vagrant/#{version}/vagrant_#{version}_darwin_#{arch}.dmg",
+        verified: "hashicorp.com/vagrant/"
+
+    pkg "vagrant.pkg"
+
+    uninstall script: {
+      executable: "uninstall.tool",
+      input: ["Yes"],
+      sudo:  true,
+    },
+    pkgutil: "com.vagrant.vagrant"
+
+    zap trash: "~/.vagrant.d"
+  end
+
   name "Vagrant"
   desc "Development environment"
   homepage "https://www.vagrantup.com/"
@@ -16,16 +31,5 @@ cask "hashicorp-vagrant" do
     url "https://github.com/hashicorp/vagrant"
     strategy :git
   end
-
-  pkg "vagrant.pkg"
-
-  uninstall script: {
-    executable: "uninstall.tool",
-    input: ["Yes"],
-    sudo:  true,
-  },
-  pkgutil: "com.vagrant.vagrant"
-
-  zap trash: "~/.vagrant.d"
 
 end


### PR DESCRIPTION
Homebrew now validates cask definitions at tap time. On Linux the arch stanza yields no match, so sha256 resolves to nil and 'brew tap' fails with: invalid 'sha256' value: nil.

Wrap arch/sha256/url and the macOS-only artifacts in on_macos blocks so the casks are skipped on non-macOS platforms.

Ref: https://github.com/orgs/Homebrew/discussions/6008

Fixes #353 

## Tested locally

```bash
developer@LAMA-LE-069:/tmp/hashicorp-tap$ git switch fix/linux-cask-validation 
branch 'fix/linux-cask-validation' set up to track 'origin/fix/linux-cask-validation'.
Switched to a new branch 'fix/linux-cask-validation'
developer@LAMA-LE-069:/tmp/hashicorp-tap$ /home/linuxbrew/.linuxbrew/bin/brew tap hashicorp/tap .
✔︎ JSON API packages.x86_64_linux.jws.json                                                                        Downloaded   15.2MB/ 15.2MB
==> Tapping hashicorp/tap
Cloning into '/home/linuxbrew/.linuxbrew/Library/Taps/hashicorp/homebrew-tap'...
done.
Tapped 2 casks and 32 formulae (100 files, 1.7MB).
```

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.


> This PR was generated with the help of AI.