### PR TITLE
Fix brew audit errors and style issues

### DIFF
--- a/Formula/hc-install.rb
+++ b/Formula/hc-install.rb
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class HcInstall < Formula
-  desc "hc-install CLI"
+  desc "CLI for installing HashiCorp products"
   homepage "https://github.com/hashicorp/hc-install"
   version "0.9.5"
 
@@ -31,13 +31,11 @@ class HcInstall < Formula
     sha256 "8e05d5526e796f2fa945b41570541a40dff4a3af6cd081744e04c728d7d62f52"
   end
 
-  conflicts_with "hc-install"
-
   def install
     bin.install "hc-install"
   end
 
   test do
-    system "#{bin}/hc-install --version"
+    system bin/"hc-install", "--version"
   end
 end

--- a/Formula/hcdiag.rb
+++ b/Formula/hcdiag.rb
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class Hcdiag < Formula
-  desc "Hcdiag"
+  desc "Diagnostic tool for HashiCorp products"
   homepage "https://github.com/hashicorp/hcdiag"
   version "0.5.13"
 
@@ -31,13 +31,11 @@ class Hcdiag < Formula
     sha256 "12551b7a8b86c93053831f7cadaff921273cca60dc53915220a3bad35fcf118e"
   end
 
-  conflicts_with "hcdiag"
-
   def install
     bin.install "hcdiag"
   end
 
   test do
-    system "#{bin}/hcdiag --version"
+    system bin/"hcdiag", "--version"
   end
 end

--- a/Formula/hcp.rb
+++ b/Formula/hcp.rb
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class Hcp < Formula
-  desc "HCP CLI"
+  desc "CLI for HashiCorp Cloud Platform"
   homepage "https://github.com/hashicorp/hcp"
   version "0.11.0"
 
@@ -31,13 +31,11 @@ class Hcp < Formula
     sha256 "2a2528756df22dbab5cfb0645ae3098c811a5f033c9a98e6171c6aa8f728bf5e"
   end
 
-  conflicts_with "hcp"
-
   def install
     bin.install "hcp"
   end
 
   test do
-    system "#{bin}/hcp --version"
+    system bin/"hcp", "--version"
   end
 end

--- a/Formula/nomad-enterprise.rb
+++ b/Formula/nomad-enterprise.rb
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class NomadEnterprise < Formula
-  desc "Nomad Enterprise"
+  desc "Enterprise workload orchestrator"
   homepage "https://www.nomadproject.io/"
   version "2.0.3+ent"
 
@@ -26,14 +26,12 @@ class NomadEnterprise < Formula
     sha256 "8e6853740dca9ae3034221223fa19f8d93e8d05edb4a3843cac48f015d6538ac"
   end
 
-  conflicts_with "nomad-enterprise"
-
   def install
     bin.install "nomad"
   end
 
   service do
-    run [bin/"nomad", "agent", "-dev"]
+    run [opt_bin/"nomad", "agent", "-dev"]
     keep_alive successful_exit: false
     working_dir var
     log_path var/"log/nomad.log"
@@ -41,6 +39,6 @@ class NomadEnterprise < Formula
   end
 
   test do
-    system "#{bin}/nomad --version"
+    system "#{bin}/nomad", "--version"
   end
 end

--- a/Formula/nomad.rb
+++ b/Formula/nomad.rb
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class Nomad < Formula
-  desc "Nomad"
+  desc "Workload orchestrator and scheduler"
   homepage "https://www.nomadproject.io/"
   version "2.0.3"
 
@@ -26,14 +26,12 @@ class Nomad < Formula
     sha256 "61cd1bf830b5db07e87ab5d1dbb73a7b23fbe4c5aed6d81dd0cddc04001b5500"
   end
 
-  conflicts_with "nomad"
-
   def install
     bin.install "nomad"
   end
 
   service do
-    run [bin/"nomad", "agent", "-dev"]
+    run [opt_bin/"nomad", "agent", "-dev"]
     keep_alive successful_exit: false
     working_dir var
     log_path var/"log/nomad.log"
@@ -41,6 +39,6 @@ class Nomad < Formula
   end
 
   test do
-    system "#{bin}/nomad --version"
+    system bin/"nomad", "--version"
   end
 end

--- a/Formula/packer.rb
+++ b/Formula/packer.rb
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class Packer < Formula
-  desc "Packer"
+  desc "Machine image builder"
   homepage "https://www.packer.io/"
   version "1.15.4"
 
@@ -31,13 +31,11 @@ class Packer < Formula
     sha256 "23e6d2e596dd9e2527e0f7bea9aedd26059729375a0d17c462c2621f1b97b82d"
   end
 
-  conflicts_with "packer"
-
   def install
     bin.install "packer"
   end
 
   test do
-    system "#{bin}/packer --version"
+    system bin/"packer", "--version"
   end
 end

--- a/Formula/sentinel.rb
+++ b/Formula/sentinel.rb
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class Sentinel < Formula
-  desc ""
+  desc "Policy as code framework"
   homepage "https://docs.hashicorp.com/sentinel"
   version "0.41.0"
 
@@ -31,13 +31,11 @@ class Sentinel < Formula
     sha256 "e4735fcfcc3f2ef161ff2b17207da2f9235ca38ba92609be43e45199f807f1b4"
   end
 
-  conflicts_with "sentinel"
-
   def install
     bin.install "sentinel"
   end
 
   test do
-    system "#{bin}/sentinel --version"
+    system bin/"sentinel", "--version"
   end
 end

--- a/Formula/terraform.rb
+++ b/Formula/terraform.rb
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class Terraform < Formula
-  desc "Terraform"
+  desc "Infrastructure as code tool"
   homepage "https://www.terraform.io/"
   version "1.15.7"
 
@@ -31,13 +31,11 @@ class Terraform < Formula
     sha256 "7a9e92105ede978cf9049a2fbe53dfe67c6a8da4b4d7f613d89e7dd7c63ec40d"
   end
 
-  conflicts_with "terraform"
-
   def install
     bin.install "terraform"
   end
 
   test do
-    system "#{bin}/terraform --version"
+    system bin/"terraform", "--version"
   end
 end

--- a/Formula/tf-migrate.rb
+++ b/Formula/tf-migrate.rb
@@ -4,7 +4,6 @@
 class TfMigrate < Formula
   desc "Terraform Migrate"
   homepage "https://www.terraform.io"
-  version "2.0.0-beta2"
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://releases.hashicorp.com/tf-migrate/2.0.0-beta2/tf-migrate_2.0.0-beta2_darwin_amd64.zip"
@@ -31,13 +30,11 @@ class TfMigrate < Formula
     sha256 "9bb4a195b3928d3684a3b0b3ad3b10a87466b56bd1f9df43622e9a45d8dd5dbc"
   end
 
-  conflicts_with "tf-migrate"
-
   def install
     bin.install "tf-migrate"
   end
 
   test do
-    system "#{bin}/tf-migrate --version"
+    system bin/"tf-migrate", "--version"
   end
 end

--- a/Formula/tfctl.rb
+++ b/Formula/tfctl.rb
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class Tfctl < Formula
-  desc ""
+  desc "CLI for Terraform Cloud"
   homepage "https://www.terraform.io"
   version "0.3.0"
 
@@ -31,13 +31,11 @@ class Tfctl < Formula
     sha256 "1060b2903cd8f9cb0af5c878cf89790e0f588b735b6715d2eeadd52c5a71f8c5"
   end
 
-  conflicts_with "tfctl"
-
   def install
     bin.install "tfctl"
   end
 
   test do
-    system "#{bin}/tfctl --version"
+    system bin/"tfctl", "--version"
   end
 end

--- a/Formula/tfstacks.rb
+++ b/Formula/tfstacks.rb
@@ -31,13 +31,11 @@ class Tfstacks < Formula
     sha256 "ab4654dc5565ef52f8e3e504233b690e9d1d2102ad0a666ad204fbd9cd4fdffc"
   end
 
-  conflicts_with "tfstacks"
-
   def install
     bin.install "tfstacks"
   end
 
   test do
-    system "#{bin}/tfstacks --version"
+    system bin/"tfstacks", "--version"
   end
 end

--- a/Formula/vault-enterprise.rb
+++ b/Formula/vault-enterprise.rb
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class VaultEnterprise < Formula
-  desc "Vault Enterprise"
+  desc "Enterprise secrets management tool"
   homepage "https://www.vaultproject.io"
   version "2.0.3+ent"
 
@@ -26,14 +26,12 @@ class VaultEnterprise < Formula
     sha256 "5f0b8436c3e30d2d22d8e45c01a6f8755ec38f207894a4d13b05b751c09ea634"
   end
 
-  conflicts_with "vault-enterprise"
-
   def install
     bin.install "vault"
   end
 
   service do
-    run [bin/"vault", "server", "-dev"]
+    run [opt_bin/"vault", "server", "-dev"]
     keep_alive successful_exit: false
     working_dir var
     log_path var/"log/vault.log"
@@ -41,6 +39,6 @@ class VaultEnterprise < Formula
   end
 
   test do
-    system "#{bin}/vault --version"
+    system "#{bin}/vault", "--version"
   end
 end

--- a/Formula/vault-radar.rb
+++ b/Formula/vault-radar.rb
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class VaultRadar < Formula
-  desc "Vault Radar"
+  desc "Security scanning tool"
   homepage "https://developer.hashicorp.com/hcp/docs/vault-radar/cli"
   version "0.50.0"
 
@@ -26,13 +26,11 @@ class VaultRadar < Formula
     sha256 "b19482e2f2ca65c3317644d67b594e58e2e426719694bbeda2372bf369323385"
   end
 
-  conflicts_with "vault-radar"
-
   def install
     bin.install "vault-radar"
   end
 
   test do
-    system "#{bin}/vault-radar --version"
+    system bin/"vault-radar", "--version"
   end
 end

--- a/Formula/vault.rb
+++ b/Formula/vault.rb
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class Vault < Formula
-  desc "Vault"
+  desc "Secrets management tool"
   homepage "https://www.vaultproject.io"
   version "2.0.3"
 
@@ -26,14 +26,12 @@ class Vault < Formula
     sha256 "9423a715aea0689f9e498fe7cc5ea692aa1eff282f8b9bc26af28cad69d6d841"
   end
 
-  conflicts_with "vault"
-
   def install
     bin.install "vault"
   end
 
   service do
-    run [bin/"vault", "server", "-dev"]
+    run [opt_bin/"vault", "server", "-dev"]
     keep_alive successful_exit: false
     working_dir var
     log_path var/"log/vault.log"
@@ -41,6 +39,6 @@ class Vault < Formula
   end
 
   test do
-    system "#{bin}/vault --version"
+    system bin/"vault", "--version"
   end
 end

--- a/Formula/vlt.rb
+++ b/Formula/vlt.rb
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class Vlt < Formula
-  desc "Vlt CLI"
+  desc "CLI for HashiCorp Vault"
   homepage "https://github.com/hashicorp/vlt"
   version "1.0.0"
 
@@ -31,13 +31,11 @@ class Vlt < Formula
     sha256 "e20529046b9a24fac9bc5d271c13db745d181c55ceed285f8d36af61a562143e"
   end
 
-  conflicts_with "vlt"
-
   def install
     bin.install "vlt"
   end
 
   test do
-    system "#{bin}/vlt --version"
+    system bin/"vlt", "--version"
   end
 end

--- a/Formula/waypoint.rb
+++ b/Formula/waypoint.rb
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 class Waypoint < Formula
-  desc "Waypoint"
+  desc "Application deployment platform"
   homepage "https://www.waypointproject.io/"
   version "0.11.4"
 
@@ -31,13 +31,11 @@ class Waypoint < Formula
     sha256 "bbf331be8785a99a0bfcb4707a013355ba58516d0e9b1b78fd8808e4d2213e66"
   end
 
-  conflicts_with "waypoint"
-
   def install
     bin.install "waypoint"
   end
 
   test do
-    system "#{bin}/waypoint --version"
+    system bin/"waypoint", "--version"
   end
 end


### PR DESCRIPTION
Fixes self-referencing "conflicts_with", redundant versions, missing sha256s, and style issues flagged by "brew audit --strict".

- Remove "conflicts_with self" declarations from all formulae
- Remove redundant version declarations where URL already contains version
- Add missing sha256 checksums to tabby formulae
- Update python@3.8 to python@3.11 in gaia
- Fix formula ordering, test blocks, and style issues

Co-Authored-By: Oz <oz-agent@warp.dev>