### PR TITLE
Bump Terraform to version 1.15.9 and update download URLs

### DIFF
--- a/Formula/terraform.rb
+++ b/Formula/terraform.rb
@@ -4,31 +4,31 @@
 class Terraform < Formula
   desc "Terraform"
   homepage "https://www.terraform.io/"
-  version "1.15.8"
+  version "1.15.9"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/terraform/1.15.8/terraform_1.15.8_darwin_amd64.zip"
-    sha256 "e2e812e783771159bf758fd4e55d6dc9bb08f63e2af2c63d212721807a02c5dc"
+    url "https://releases.hashicorp.com/terraform/1.15.9/terraform_1.15.9_darwin_amd64.zip"
+    sha256 "3e97c499fac8074adfa3760300662a0158f2fd325144965dd0028deec4086c6b"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/terraform/1.15.8/terraform_1.15.8_darwin_arm64.zip"
-    sha256 "f210110c5698b94d803a7a63cdb0251b5455c150841478808e2bbb343f95ed68"
+    url "https://releases.hashicorp.com/terraform/1.15.9/terraform_1.15.9_darwin_arm64.zip"
+    sha256 "05b27586a5d7d84105690ecccc7edbbf48bc3d6d577745cb61f163ba990adf4f"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/terraform/1.15.8/terraform_1.15.8_linux_amd64.zip"
-    sha256 "d25ce7b6902013ad905db3d2eab0be4cd905887fe88b81a6171b8d5503c31f3d"
+    url "https://releases.hashicorp.com/terraform/1.15.9/terraform_1.15.9_linux_amd64.zip"
+    sha256 "76edd0b22d2f27d3d2e097cd793209646f719cf60f02ff3af626b07361137da1"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/terraform/1.15.8/terraform_1.15.8_linux_arm.zip"
-    sha256 "9e6964abf11a84db1fa84d67adbfb9caf52ef5d03fdc1beb122c66129b9337d4"
+    url "https://releases.hashicorp.com/terraform/1.15.9/terraform_1.15.9_linux_arm.zip"
+    sha256 "9b7a67a2ff2db4768a697db96fa5859ae4c9490f7c4f365fa8b9b40ec7b870ae"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/terraform/1.15.8/terraform_1.15.8_linux_arm64.zip"
-    sha256 "8891e9dcedc9e3b8950bc6af9d4d8af1f4cfade3062f53b9dc403a89f6ce8c9c"
+    url "https://releases.hashicorp.com/terraform/1.15.9/terraform_1.15.9_linux_arm64.zip"
+    sha256 "0afa6c29f61ca5ea270e950e43e50ecf2418b598507bf580e8ae76e1e6699b19"
   end
 
   conflicts_with "terraform"


### PR DESCRIPTION
Bump Terraform to version 1.15.9 and update download URLs