### PR TITLE
SMRE-1277: fix(ci): create PR and auto-merge for brew-tap updates to respect branch policy

### DIFF
--- a/.github/scripts/check-version.sh
+++ b/.github/scripts/check-version.sh
@@ -2,9 +2,9 @@
 
 # Version checking script for Homebrew tap updates
 # Usage: check-version.sh <product_name> <incoming_version> <is_cask>
-# 
+#
 # Modes:
-# - Cask mode: is_cask="true" (checks ./Casks/<product_name>.rb)
+# - Cask mode: is_cask="true" (checks ./Casks/hashicorp-<product_name>.rb)
 # - Formula mode: is_cask="false" (checks ./Formula/<product_name>.rb)
 # - Both mode: NOT SUPPORTED - script only handles one file at a time
 #   For both mode, call this script twice with different is_cask values
@@ -58,7 +58,7 @@ get_file_path() {
     local is_cask="$2"
     
     if [[ "$is_cask" == "true" ]]; then
-        echo "./Casks/${product_name}.rb"
+        echo "./Casks/hashicorp-${product_name}.rb"
     else
         echo "./Formula/${product_name}.rb"
     fi

--- a/.github/scripts/tests/check-version.bats
+++ b/.github/scripts/tests/check-version.bats
@@ -23,7 +23,8 @@ setup() {
     
     # Copy test data
     cp "$TEST_DIR/data/test-formula.rb" "$TEMP_DIR/Formula/"
-    cp "$TEST_DIR/data/test-cask.rb" "$TEMP_DIR/Casks/"
+    # Cask filenames are prefixed with "hashicorp-" on disk; mirror that here.
+    cp "$TEST_DIR/data/test-cask.rb" "$TEMP_DIR/Casks/hashicorp-test-cask.rb"
     cp "$TEST_DIR/data/old-version.rb" "$TEMP_DIR/Formula/"
 }
 
@@ -112,10 +113,20 @@ get_output_value() {
     [ "$should_update" = "true" ]
 }
 
-
 @test "cask version comparison works (older)" {
     run_check_version "test-cask" "2.0.9" "true"
     [ "$status" -eq 0 ]
+    should_update=$(get_output_value "$output" "should_update")
+    [ "$should_update" = "false" ]
+}
+
+@test "cask path resolves to hashicorp- prefix" {
+    # Confirms get_file_path uses ./Casks/hashicorp-<product>.rb for casks.
+    # Without the prefix the file would not be found and should_update would
+    # always be reported as true (new-product path), bypassing version gating.
+    run_check_version "test-cask" "2.1.0" "true"
+    [ "$status" -eq 0 ]
+    # Same version → should NOT update; proves the file was actually read.
     should_update=$(get_output_value "$output" "should_update")
     [ "$should_update" = "false" ]
 }

--- a/.github/workflows/manual-publish-formula-update.yml
+++ b/.github/workflows/manual-publish-formula-update.yml
@@ -6,8 +6,10 @@ on:
       inputs:
         product:
           description: product name as it appears in binary (ie. "vault", "vault-enterprise", etc.)
+          required: true
         version:
           description: semantic version string (ie. "1.12.2")
+          required: true
         is_cask:
           type: boolean
           description: check if updating a cask (rather than a tap formula)
@@ -51,17 +53,71 @@ jobs:
             ${{github.event.inputs.version}} \
             ./util/formula_templater/config.hcl > ./Casks/hashicorp-${{github.event.inputs.product}}.rb
 
-      - name: Publish Change
+      - name: Publish Change via Pull Request
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_UPDATER_TOKEN }}
+          PRODUCT: ${{ github.event.inputs.product }}
+          VERSION: ${{ github.event.inputs.version }}
+          IS_CASK: ${{ github.event.inputs.is_cask }}
         run: |
           git config user.name hc-github-team-es-release-engineering
           git config user.email github-team-es-release-engineering@hashicorp.com
 
-          git add Formula/*.rb Casks/*.rb
+          # Stage only the file that was generated — avoids glob expansion errors
+          # when the other directory has no matching changes.
+          if [[ "$IS_CASK" == "true" ]]; then
+            git add "Casks/hashicorp-${PRODUCT}.rb"
+          else
+            git add "Formula/${PRODUCT}.rb"
+          fi
 
-          git commit -m "Bump ${{ github.event.inputs.product }} to ${{ github.event.inputs.version }}"
+          # Exit early if the generated file is identical to what is already
+          # committed (e.g. re-running for a version that is already current).
+          if git diff --staged --quiet; then
+            echo "::notice::Generated file is unchanged — nothing to commit for ${PRODUCT} ${VERSION}."
+            exit 0
+          fi
 
-          # Ensure we have any changes that might have been merged before we push. This narrows the window in which a 
-          # race from multiple changes happening at once can occur. Conflicts/Races could still occur though unlikley.
-          git pull --rebase
+          # Deterministic branch name — one open PR per product per version.
+          BRANCH="automation/bump-${PRODUCT}-${VERSION}"
 
-          git push
+          git checkout -b "$BRANCH"
+          git commit -m "Bump ${PRODUCT} to ${VERSION}"
+
+          # Fetch the remote branch first so --force-with-lease has a tracking ref
+          # to compare against. actions/checkout only fetches master, so without
+          # this fetch the lease check has nothing to compare and behaves like
+          # plain --force. The 2>/dev/null || true makes it a no-op when the
+          # branch doesn't exist yet (first push).
+          git fetch origin "$BRANCH" 2>/dev/null || true
+          git push --force-with-lease origin "$BRANCH"
+
+          # Open a PR only if one doesn't already exist for this branch.
+          # Capture the PR number at creation time to avoid a second API call
+          # and the race condition of querying a PR that may not be indexed yet.
+          EXISTING_PR=$(gh pr list \
+            --head "$BRANCH" \
+            --state open \
+            --json number \
+            --jq '.[0].number')
+
+          if [[ -z "$EXISTING_PR" ]]; then
+            PR_URL=$(gh pr create \
+              --base master \
+              --head "$BRANCH" \
+              --title "Bump ${PRODUCT} to ${VERSION}" \
+              --body "Automated version bump for \`${PRODUCT}\` to \`${VERSION}\`.")
+            # Extract the PR number from the URL returned by gh pr create.
+            PR_NUMBER="${PR_URL##*/}"
+          else
+            echo "::notice::PR #${EXISTING_PR} already exists for ${BRANCH}, skipping PR creation."
+            PR_NUMBER="$EXISTING_PR"
+          fi
+
+          # Enable auto-merge so the PR merges automatically once required checks pass.
+          if [[ -n "$PR_NUMBER" ]]; then
+            gh pr merge "$PR_NUMBER" --auto --merge
+          else
+            echo "::error::Could not determine PR number for ${BRANCH} — auto-merge not enabled."
+            exit 1
+          fi

--- a/.github/workflows/publish-formula-update.yml
+++ b/.github/workflows/publish-formula-update.yml
@@ -88,17 +88,71 @@ jobs:
             ${{github.event.client_payload.version}} \
             ./util/formula_templater/config.hcl > ./Casks/hashicorp-${{github.event.client_payload.name}}.rb
 
-      - name: Publish Change
+      - name: Publish Change via Pull Request
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_UPDATER_TOKEN }}
+          PRODUCT: ${{ github.event.client_payload.name }}
+          VERSION: ${{ github.event.client_payload.version }}
+          IS_CASK: ${{ github.event.client_payload.cask }}
         run: |
           git config user.name hc-github-team-es-release-engineering
           git config user.email github-team-es-release-engineering@hashicorp.com
-          
-          git add Formula/*.rb Casks/*.rb
 
-          git commit -m "Bump ${{ github.event.client_payload.name }} to ${{ github.event.client_payload.version }}"
+          # Stage only the file that was generated — avoids glob expansion errors
+          # when the other directory has no matching changes.
+          if [[ "$IS_CASK" == "true" ]]; then
+            git add "Casks/hashicorp-${PRODUCT}.rb"
+          else
+            git add "Formula/${PRODUCT}.rb"
+          fi
 
-          # Ensure we have any changes that might have been merged before we push. This narrows the window in which a
-          # race from multiple changes happening at once can occur. Conflicts/Races could still occur though unlikley.
-          git pull --rebase
+          # Exit early if the generated file is identical to what is already
+          # committed (e.g. a duplicate dispatch for the same version).
+          if git diff --staged --quiet; then
+            echo "::notice::Generated file is unchanged — nothing to commit for ${PRODUCT} ${VERSION}."
+            exit 0
+          fi
 
-          git push
+          # Deterministic branch name — one open PR per product per version.
+          BRANCH="automation/bump-${PRODUCT}-${VERSION}"
+
+          git checkout -b "$BRANCH"
+          git commit -m "Bump ${PRODUCT} to ${VERSION}"
+
+          # Fetch the remote branch first so --force-with-lease has a tracking ref
+          # to compare against. actions/checkout only fetches master, so without
+          # this fetch the lease check has nothing to compare and behaves like
+          # plain --force. The 2>/dev/null || true makes it a no-op when the
+          # branch doesn't exist yet (first push).
+          git fetch origin "$BRANCH" 2>/dev/null || true
+          git push --force-with-lease origin "$BRANCH"
+
+          # Open a PR only if one doesn't already exist for this branch.
+          # Capture the PR number at creation time to avoid a second API call
+          # and the race condition of querying a PR that may not be indexed yet.
+          EXISTING_PR=$(gh pr list \
+            --head "$BRANCH" \
+            --state open \
+            --json number \
+            --jq '.[0].number')
+
+          if [[ -z "$EXISTING_PR" ]]; then
+            PR_URL=$(gh pr create \
+              --base master \
+              --head "$BRANCH" \
+              --title "Bump ${PRODUCT} to ${VERSION}" \
+              --body "Automated version bump for \`${PRODUCT}\` to \`${VERSION}\`.")
+            # Extract the PR number from the URL returned by gh pr create.
+            PR_NUMBER="${PR_URL##*/}"
+          else
+            echo "::notice::PR #${EXISTING_PR} already exists for ${BRANCH}, skipping PR creation."
+            PR_NUMBER="$EXISTING_PR"
+          fi
+
+          # Enable auto-merge so the PR merges automatically once required checks pass.
+          if [[ -n "$PR_NUMBER" ]]; then
+            gh pr merge "$PR_NUMBER" --auto --merge
+          else
+            echo "::error::Could not determine PR number for ${BRANCH} — auto-merge not enabled."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
Fixes formula update automation which was failing because `master` requires PRs — direct pushes are blocked by branch protection.

## Changes
- **`publish-formula-update.yml` / `manual-publish-formula-update.yml`**: push generated formula/cask to a deterministic branch (`automation/bump-<product>-<version>`), open a PR, and enable auto-merge via `gh pr merge --auto`. Additional hardening: targeted `git add` (no glob), `--force-with-lease`, empty-commit guard, single `gh pr list` call, explicit error if PR number cannot be resolved.
- **`check-version.sh`**: fix cask file path to include `hashicorp-` prefix — previously the version gate was always bypassed for cask dispatches.
- **`check-version.bats`**: fix cask test fixture filename to match; add test asserting cask path resolves correctly.

Related to: https://github.com/hashicorp/releng-support/issues/1232
Jira: [SMRE-1277](https://hashicorp.atlassian.net/browse/SMRE-1277)

[SMRE-1277]: https://hashicorp.atlassian.net/browse/SMRE-1277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ