### PR TITLE
SMRE-1277: fix auto-merge strategy to squash

### DIFF
--- a/.github/workflows/manual-publish-formula-update.yml
+++ b/.github/workflows/manual-publish-formula-update.yml
@@ -116,7 +116,7 @@ jobs:
 
           # Enable auto-merge so the PR merges automatically once required checks pass.
           if [[ -n "$PR_NUMBER" ]]; then
-            gh pr merge "$PR_NUMBER" --auto --merge
+            gh pr merge "$PR_NUMBER" --auto --squash
           else
             echo "::error::Could not determine PR number for ${BRANCH} — auto-merge not enabled."
             exit 1

--- a/.github/workflows/publish-formula-update.yml
+++ b/.github/workflows/publish-formula-update.yml
@@ -151,7 +151,7 @@ jobs:
 
           # Enable auto-merge so the PR merges automatically once required checks pass.
           if [[ -n "$PR_NUMBER" ]]; then
-            gh pr merge "$PR_NUMBER" --auto --merge
+            gh pr merge "$PR_NUMBER" --auto --squash
           else
             echo "::error::Could not determine PR number for ${BRANCH} — auto-merge not enabled."
             exit 1


### PR DESCRIPTION
## Problem
`gh pr merge --auto --merge` was failing with:
`GraphQL: Merge method merge commits are not allowed on this repository (enablePullRequestAutoMerge)`

## Fix
Swap `--merge` → `--squash` in both `publish-formula-update.yml` and `manual-publish-formula-update.yml`. Squash merge is the only strategy enabled on this repository.

Jira: [SMRE-1277](https://hashicorp.atlassian.net/browse/SMRE-1277)

[SMRE-1277]: https://hashicorp.atlassian.net/browse/SMRE-1277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ