### PR TITLE
Bump vault-enterprise to 2.0.4+ent

### DIFF
--- a/Formula/vault-enterprise.rb
+++ b/Formula/vault-enterprise.rb
@@ -4,26 +4,26 @@
 class VaultEnterprise < Formula
   desc "Vault Enterprise"
   homepage "https://www.vaultproject.io"
-  version "2.0.3+ent"
+  version "2.0.4+ent"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/vault/2.0.3+ent/vault_2.0.3+ent_darwin_amd64.zip"
-    sha256 "9816c92cc9c3a5130dc020b88febcf546f650e88986624df33aae29729b7c33f"
+    url "https://releases.hashicorp.com/vault/2.0.4+ent/vault_2.0.4+ent_darwin_amd64.zip"
+    sha256 "5f2b2d89b0eb3f5e6f6d4c142c45837c37a5515fbe0613a179238eb147c32689"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/vault/2.0.3+ent/vault_2.0.3+ent_darwin_arm64.zip"
-    sha256 "67616d1e41e75dcb00f79bf5a3c43e22cc29dba4a834854e6b14c8f6ef3a1021"
+    url "https://releases.hashicorp.com/vault/2.0.4+ent/vault_2.0.4+ent_darwin_arm64.zip"
+    sha256 "7bb34caf0ff82e3885cb06fe11af2526ff190ddd2e09e720c56aaf60c481dd7d"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/vault/2.0.3+ent/vault_2.0.3+ent_linux_amd64.zip"
-    sha256 "14239bce32f4826c7bc0b563dc67f46cc21db3854897997fcabb5e8339c87428"
+    url "https://releases.hashicorp.com/vault/2.0.4+ent/vault_2.0.4+ent_linux_amd64.zip"
+    sha256 "997b3c0553774911bb4842faeeae616d8bc34bfa91ba6f1fccd5ae36e5b92b88"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/vault/2.0.3+ent/vault_2.0.3+ent_linux_arm64.zip"
-    sha256 "5f0b8436c3e30d2d22d8e45c01a6f8755ec38f207894a4d13b05b751c09ea634"
+    url "https://releases.hashicorp.com/vault/2.0.4+ent/vault_2.0.4+ent_linux_arm64.zip"
+    sha256 "07acea98be629ad5668e7614a18c40c9c5e7b643f7780bfcb14a925b4251a8dc"
   end
 
   conflicts_with "vault-enterprise"


### PR DESCRIPTION
Automated version bump for `vault-enterprise` to `2.0.4+ent`.