### PR TITLE
Bump nomad-enterprise to 2.0.5+ent

### DIFF
--- a/Formula/nomad-enterprise.rb
+++ b/Formula/nomad-enterprise.rb
@@ -4,26 +4,26 @@
 class NomadEnterprise < Formula
   desc "Nomad Enterprise"
   homepage "https://www.nomadproject.io/"
-  version "2.0.4+ent"
+  version "2.0.5+ent"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/nomad/2.0.4+ent/nomad_2.0.4+ent_darwin_amd64.zip"
-    sha256 "21f3c49a49c5dbb55ab864dca28abbe1b91c129ef659d1961a2b1ea5246f5b42"
+    url "https://releases.hashicorp.com/nomad/2.0.5+ent/nomad_2.0.5+ent_darwin_amd64.zip"
+    sha256 "4d8050051c48ab91d7e281691e67ab173ffc4ee87ae913c442cb80588f87c951"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/nomad/2.0.4+ent/nomad_2.0.4+ent_darwin_arm64.zip"
-    sha256 "c68f13ff078f6644da46836962f38fac209c80a5b4176fec67e31a3e4ffd9446"
+    url "https://releases.hashicorp.com/nomad/2.0.5+ent/nomad_2.0.5+ent_darwin_arm64.zip"
+    sha256 "9d50beb8ffc63fcdfb27c082facfbf64dc25086b8ae26e1c98f877ea09334185"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/nomad/2.0.4+ent/nomad_2.0.4+ent_linux_amd64.zip"
-    sha256 "9d919c6faf9abd164be8d972344c8a2bde124b9fef7bafde248b420ca43e96f0"
+    url "https://releases.hashicorp.com/nomad/2.0.5+ent/nomad_2.0.5+ent_linux_amd64.zip"
+    sha256 "37e51fee58d2f7c88ec9e38c9e61a6c0ad4c91a2370ea798427f50991f7cd3ab"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/nomad/2.0.4+ent/nomad_2.0.4+ent_linux_arm64.zip"
-    sha256 "bf815fb72b895c4abc34adcf4ddb63b7fd92efad6f08152e381b225a2bb89330"
+    url "https://releases.hashicorp.com/nomad/2.0.5+ent/nomad_2.0.5+ent_linux_arm64.zip"
+    sha256 "cf66d9346b4e034b2b7fcb14d763612dea6d993a9743c4fa4cf84191e3827a3a"
   end
 
   conflicts_with "nomad-enterprise"


### PR DESCRIPTION
Automated version bump for `nomad-enterprise` to `2.0.5+ent`.