### PR TITLE
Bump terraform to 1.16.0

### DIFF
--- a/Formula/terraform.rb
+++ b/Formula/terraform.rb
@@ -4,31 +4,31 @@
 class Terraform < Formula
   desc "Terraform"
   homepage "https://www.terraform.io/"
-  version "1.15.9"
+  version "1.16.0"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/terraform/1.15.9/terraform_1.15.9_darwin_amd64.zip"
-    sha256 "3e97c499fac8074adfa3760300662a0158f2fd325144965dd0028deec4086c6b"
+    url "https://releases.hashicorp.com/terraform/1.16.0/terraform_1.16.0_darwin_amd64.zip"
+    sha256 "2b2b7d37f6893474fa3622fa96053e54949c4ddfca4aba105380718157936465"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/terraform/1.15.9/terraform_1.15.9_darwin_arm64.zip"
-    sha256 "05b27586a5d7d84105690ecccc7edbbf48bc3d6d577745cb61f163ba990adf4f"
+    url "https://releases.hashicorp.com/terraform/1.16.0/terraform_1.16.0_darwin_arm64.zip"
+    sha256 "5dd692c6cc76b596029ff3c2b2b4c3a1710f92d3de6d2da3f66bd2e0c2daa92a"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/terraform/1.15.9/terraform_1.15.9_linux_amd64.zip"
-    sha256 "76edd0b22d2f27d3d2e097cd793209646f719cf60f02ff3af626b07361137da1"
+    url "https://releases.hashicorp.com/terraform/1.16.0/terraform_1.16.0_linux_amd64.zip"
+    sha256 "41d05b927aa174f15d1228c4eba832a323b716c68b415ef5a00179f46cc602d3"
   end
 
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/terraform/1.15.9/terraform_1.15.9_linux_arm.zip"
-    sha256 "9b7a67a2ff2db4768a697db96fa5859ae4c9490f7c4f365fa8b9b40ec7b870ae"
+    url "https://releases.hashicorp.com/terraform/1.16.0/terraform_1.16.0_linux_arm.zip"
+    sha256 "ae6f7a891fa7d65b30d7c1cebcd02b2ea2998632ec3def200b4fb9d3d3f135c9"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/terraform/1.15.9/terraform_1.15.9_linux_arm64.zip"
-    sha256 "0afa6c29f61ca5ea270e950e43e50ecf2418b598507bf580e8ae76e1e6699b19"
+    url "https://releases.hashicorp.com/terraform/1.16.0/terraform_1.16.0_linux_arm64.zip"
+    sha256 "60f86cea49a653e22a93c000f16cbfa391ce41c6f6a11d36557c35da411f684c"
   end
 
   conflicts_with "terraform"


### PR DESCRIPTION
Automated version bump for `terraform` to `1.16.0`.