### PR TITLE
Bump vault-radar to 0.53.0

### DIFF
--- a/Formula/vault-radar.rb
+++ b/Formula/vault-radar.rb
@@ -4,26 +4,26 @@
 class VaultRadar < Formula
   desc "Vault Radar"
   homepage "https://developer.hashicorp.com/hcp/docs/vault-radar/cli"
-  version "0.52.0"
+  version "0.53.0"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/vault-radar/0.52.0/vault-radar_0.52.0_darwin_amd64.zip"
-    sha256 "81b3fbd8c944850f417fa9e3c06a197891c0b96fe54eb156e2a4b03fb439093e"
+    url "https://releases.hashicorp.com/vault-radar/0.53.0/vault-radar_0.53.0_darwin_amd64.zip"
+    sha256 "f732c0eebe20151004311910ab767e6947037b82d3ed0f93a0789693d9f8012f"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://releases.hashicorp.com/vault-radar/0.52.0/vault-radar_0.52.0_darwin_arm64.zip"
-    sha256 "9e97c806de4c27010beff516b24b0202c194b3c6c7076fa064fb214250b0ee96"
+    url "https://releases.hashicorp.com/vault-radar/0.53.0/vault-radar_0.53.0_darwin_arm64.zip"
+    sha256 "8364000f50f6d275f8f658931d3203764711beaf86ece608f1e31d88edc48a40"
   end
 
   if OS.linux? && Hardware::CPU.intel?
-    url "https://releases.hashicorp.com/vault-radar/0.52.0/vault-radar_0.52.0_linux_amd64.zip"
-    sha256 "a316953b9195ba135411b4c21defcacff79e39185704f0f057c1bb1d7d9258f9"
+    url "https://releases.hashicorp.com/vault-radar/0.53.0/vault-radar_0.53.0_linux_amd64.zip"
+    sha256 "e89a9764fcb687fff627b34c13d5b2295c2bc899e945d15c203c81e58c6c5055"
   end
 
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url "https://releases.hashicorp.com/vault-radar/0.52.0/vault-radar_0.52.0_linux_arm64.zip"
-    sha256 "6c9a774f6d1789d04adba91c2e5e8d7f8fb984d6a20b07d33ff7c5aac08c9faa"
+    url "https://releases.hashicorp.com/vault-radar/0.53.0/vault-radar_0.53.0_linux_arm64.zip"
+    sha256 "00f0ef9d99f0e2af0c85e0fbc8894d837239d6aa9fea70256bba8f64090d7cd5"
   end
 
   conflicts_with "vault-radar"


### PR DESCRIPTION
Automated version bump for `vault-radar` to `0.53.0`.